### PR TITLE
Revert "Switching from xUnit to NUnit"

### DIFF
--- a/ParserExample/ParserExample.csproj
+++ b/ParserExample/ParserExample.csproj
@@ -9,7 +9,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ParserTests/EBNFTests.cs
+++ b/ParserTests/EBNFTests.cs
@@ -1,16 +1,17 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using jsonparser;
-using NUnit.Framework;
-using sly.lexer;
+﻿using System.Linq;
+using Xunit;
 using sly.parser;
+using sly.lexer;
 using sly.parser.generator;
+using System.Collections.Generic;
+using expressionparser;
 using sly.parser.llparser;
 using sly.parser.syntax;
+using jsonparser;
 
 namespace ParserTests
 {
-    [TestFixture]
+    
     public class EBNFTests
     {
 
@@ -64,7 +65,7 @@ namespace ParserTests
         }
 
         [Production("G : e f ")]
-        public object RManyNT(Token<TokenType> e, Token<TokenType> f)
+        public object RManyNT(Token<TokenType> e , Token<TokenType> f)
         {
             string result = $"G({e.Value},{f.Value})";
             return result;
@@ -74,7 +75,7 @@ namespace ParserTests
         public object A(List<Token<TokenType>> astr)
         {
             string result = "A(";
-            result += (string)astr
+            result +=(string) astr
                 .Select(a => a.Value)
                 .Aggregate<string>((a1, a2) => a1 + ", " + a2);
             result += ")";
@@ -100,11 +101,16 @@ namespace ParserTests
 
         private Parser<JsonToken> JsonParser;
 
+        public EBNFTests()
+        {
+            
+        }
+
         private Parser<TokenType> BuildParser()
         {
             EBNFTests parserInstance = new EBNFTests();
             ParserBuilder builder = new ParserBuilder();
-
+            
             Parser = builder.BuildParser<TokenType>(parserInstance, ParserType.EBNF_LL_RECURSIVE_DESCENT, "R");
             return Parser;
         }
@@ -119,47 +125,49 @@ namespace ParserTests
             return JsonParser;
         }
 
-        [Test]
+        [Fact]
         public void TestParseBuild()
         {
             Parser = BuildParser();
-            Assert.AreEqual(typeof(EBNFRecursiveDescentSyntaxParser<TokenType>), Parser.SyntaxParser.GetType());
-            Assert.AreEqual(Parser.Configuration.NonTerminals.Count, 4);
+            Assert.Equal(typeof(EBNFRecursiveDescentSyntaxParser<TokenType>),Parser.SyntaxParser.GetType());
+            Assert.Equal(Parser.Configuration.NonTerminals.Count, 4);
             NonTerminal<TokenType> nt = Parser.Configuration.NonTerminals["R"];
-            Assert.AreEqual(nt.Rules.Count, 2);
+            Assert.Equal(nt.Rules.Count, 2);
             nt = Parser.Configuration.NonTerminals["A"];
-            Assert.AreEqual(nt.Rules.Count, 1);
+            Assert.Equal(nt.Rules.Count, 1);
             Rule<TokenType> rule = nt.Rules[0];
-            Assert.AreEqual(rule.Clauses.Count, 1);
-            Assert.IsInstanceOf<OneOrMoreClause<TokenType>>(rule.Clauses[0]);
-            nt = Parser.Configuration.NonTerminals["B"];
-            Assert.AreEqual(nt.Rules.Count, 1);
+            Assert.Equal(rule.Clauses.Count,1);
+            Assert.IsType(typeof(OneOrMoreClause<TokenType>),rule.Clauses[0]);
+                nt = Parser.Configuration.NonTerminals["B"];
+            Assert.Equal(nt.Rules.Count, 1);
             rule = nt.Rules[0];
-            Assert.AreEqual(rule.Clauses.Count, 1);
-            Assert.IsInstanceOf<ZeroOrMoreClause<TokenType>>(rule.Clauses[0]);
+            Assert.Equal(rule.Clauses.Count, 1);
+            Assert.IsType(typeof(ZeroOrMoreClause<TokenType>), rule.Clauses[0]);
+            ;
         }
 
-        [Test]
+
+        [Fact]
         public void TestOneOrMoreNonTerminal()
         {
             Parser = BuildParser();
             ParseResult<TokenType> result = Parser.Parse("e f e f");
             Assert.False(result.IsError);
-            Assert.IsInstanceOf<string>(result.Result);
-            Assert.AreEqual("R(G(e,f),G(e,f))", result.Result.ToString().Replace(" ", ""));
+            Assert.IsType(typeof(string), result.Result);
+            Assert.Equal("R(G(e,f),G(e,f))", result.Result.ToString().Replace(" ", ""));
         }
 
-        [Test]
+        [Fact]
         public void TestOneOrMoreWithMany()
         {
             Parser = BuildParser();
             ParseResult<TokenType> result = Parser.Parse("aaa b c");
             Assert.False(result.IsError);
-            Assert.IsInstanceOf<string>(result.Result);
-            Assert.AreEqual("R(A(a,a,a),B(b),c)", result.Result.ToString().Replace(" ", ""));
+            Assert.IsType(typeof(string),result.Result);
+            Assert.Equal("R(A(a,a,a),B(b),c)",result.Result.ToString().Replace(" ",""));
         }
 
-        [Test]
+        [Fact]
         public void TestOneOrMoreWithOne()
         {
             Parser = BuildParser();
@@ -167,61 +175,61 @@ namespace ParserTests
             Assert.True(result.IsError);
         }
 
-        [Test]
+        [Fact]
         public void TestZeroOrMoreWithOne()
         {
             Parser = BuildParser();
             ParseResult<TokenType> result = Parser.Parse("a b c");
             Assert.False(result.IsError);
-            Assert.IsInstanceOf<string>(result.Result);
-            Assert.AreEqual("R(A(a),B(b),c)", result.Result.ToString().Replace(" ", ""));
+            Assert.IsType(typeof(string), result.Result);
+            Assert.Equal("R(A(a),B(b),c)", result.Result.ToString().Replace(" ", ""));
         }
 
-        [Test]
+        [Fact]
         public void TestZeroOrMoreWithMany()
         {
             Parser = BuildParser();
             ParseResult<TokenType> result = Parser.Parse("a bb c");
             Assert.False(result.IsError);
-            Assert.IsInstanceOf<string>(result.Result);
-            Assert.AreEqual("R(A(a),B(b,b),c)", result.Result.ToString().Replace(" ", ""));
+            Assert.IsType(typeof(string), result.Result);
+            Assert.Equal("R(A(a),B(b,b),c)", result.Result.ToString().Replace(" ", ""));
         }
 
-        [Test]
+        [Fact]
         public void TestZeroOrMoreWithNone()
         {
             Parser = BuildParser();
             ParseResult<TokenType> result = Parser.Parse("a  c");
             Assert.False(result.IsError);
-            Assert.IsInstanceOf<string>(result.Result);
-            Assert.AreEqual("R(A(a),B(),c)", result.Result.ToString().Replace(" ", ""));
+            Assert.IsType(typeof(string), result.Result);
+            Assert.Equal("R(A(a),B(),c)", result.Result.ToString().Replace(" ", ""));
         }
 
 
-        [Test]
+        [Fact]
         public void TestJsonList()
         {
             Parser<JsonToken> jsonParser = BuildEbnfJsonParser();
             ParseResult<JsonToken> result = jsonParser.Parse("[1,2,3,4]");
             Assert.False(result.IsError);
             Assert.IsAssignableFrom(typeof(List<object>), result.Result);
-            Assert.AreEqual(4, ((List<object>)result.Result).Count);
+            Assert.Equal(4, ((List<object>)result.Result).Count);
             List<object> lsto = (List<object>)result.Result;
-            Assert.AreEqual(new List<object> { 1, 2, 3, 4 }, lsto);
+            Assert.Equal(new List<object> { 1, 2, 3, 4 }, lsto);
         }
 
-        [Test]
+        [Fact]
         public void TestJsonObject()
         {
             Parser<JsonToken> jsonParser = BuildEbnfJsonParser();
             ParseResult<JsonToken> result = jsonParser.Parse("{\"one\":1,\"two\":2,\"three\":\"trois\" }");
             Assert.False(result.IsError);
-            Assert.IsAssignableFrom(typeof(Dictionary<string, object>), result.Result);
-            Assert.AreEqual(3, ((Dictionary<string, object>)result.Result).Count);
+            Assert.IsAssignableFrom(typeof(Dictionary<string,object>), result.Result);
+            Assert.Equal(3, ((Dictionary<string, object>)result.Result).Count);
             Dictionary<string, object> dico = (Dictionary<string, object>)result.Result;
-            Assert.AreEqual(1, dico["one"]);
-            Assert.AreEqual(2, dico["two"]);
-            Assert.AreEqual("trois", dico["three"]);
+            Assert.Equal(1,dico["one"]);
+            Assert.Equal(2, dico["two"]);
+            Assert.Equal("trois", dico["three"]);
         }
 
 

--- a/ParserTests/ErrorTests.cs
+++ b/ParserTests/ErrorTests.cs
@@ -1,21 +1,26 @@
-﻿using expressionparser;
+﻿using sly.parser;
+using expressionparser;
 using jsonparser;
-using NUnit.Framework;
 using sly.lexer;
-using sly.parser;
 using sly.parser.generator;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
 
 namespace ParserTests
 {
-    [TestFixture]
     public class ErrorTests
     {
-        [Test]
+
+
+        [Fact]
         public void TestJsonSyntaxError()
         {
             JSONParser jsonParser = new JSONParser();
             ParserBuilder builder = new ParserBuilder();
             Parser<JsonToken> parser = builder.BuildParser<JsonToken>(jsonParser, ParserType.LL_RECURSIVE_DESCENT, "root");
+
 
             string source = @"{
                 'one': 1,
@@ -29,13 +34,13 @@ namespace ParserTests
             Assert.IsAssignableFrom(typeof(UnexpectedTokenSyntaxError<JsonToken>), r.Errors[0]);
             UnexpectedTokenSyntaxError<JsonToken> error = r.Errors[0] as UnexpectedTokenSyntaxError<JsonToken>;
 
-            Assert.AreEqual(JsonToken.COMMA, error?.UnexpectedToken.TokenID);
-            Assert.AreEqual(3, error?.Line);
-            Assert.AreEqual(24, error?.Column);
+            Assert.Equal(JsonToken.COMMA, error?.UnexpectedToken.TokenID);
+            Assert.Equal(3, error?.Line);
+            Assert.Equal(24, error?.Column);
 
         }
 
-        [Test]
+        [Fact]
         public void TestExpressionSyntaxError()
         {
             ExpressionParser exprParser = new ExpressionParser();
@@ -50,13 +55,13 @@ namespace ParserTests
             Assert.IsAssignableFrom(typeof(UnexpectedTokenSyntaxError<ExpressionToken>), r.Errors[0]);
             UnexpectedTokenSyntaxError<ExpressionToken> error = r.Errors[0] as UnexpectedTokenSyntaxError<ExpressionToken>;
 
-            Assert.AreEqual(ExpressionToken.PLUS, error.UnexpectedToken.TokenID);
+            Assert.Equal(ExpressionToken.PLUS, error.UnexpectedToken.TokenID);
 
-            Assert.AreEqual(1, error.Line);
-            Assert.AreEqual(10, error.Column);
+            Assert.Equal(1, error.Line);
+            Assert.Equal(10, error.Column);
         }
 
-        [Test]
+        [Fact]
         public void TestLexicalError()
         {
             ExpressionParser exprParser = new ExpressionParser();
@@ -70,9 +75,9 @@ namespace ParserTests
             Assert.True(r.Errors.Count > 0);
             Assert.IsAssignableFrom(typeof(LexicalError), r.Errors[0]);
             LexicalError error = r.Errors[0] as LexicalError;
-            Assert.AreEqual(1, error.Line);
-            Assert.AreEqual(3, error.Column);
-            Assert.AreEqual('@', error.UnexpectedChar);
+            Assert.Equal(1, error.Line);
+            Assert.Equal(3, error.Column);
+            Assert.Equal('@', error.UnexpectedChar);
         }
     }
 }

--- a/ParserTests/ExpressionTests.cs
+++ b/ParserTests/ExpressionTests.cs
@@ -1,15 +1,19 @@
-﻿using expressionparser;
-using NUnit.Framework;
+﻿using System.Linq;
+using Xunit;
 using sly.parser;
+using sly.lexer;
 using sly.parser.generator;
+using System.Collections.Generic;
+using expressionparser;
 
 namespace ParserTests
 {
-    [TestFixture]
+    
     public class ExpressionTests
     {
-        private readonly Parser<ExpressionToken> Parser;
 
+        private Parser<ExpressionToken> Parser;
+      
         public ExpressionTests()
         {
             ExpressionParser parserInstance = new ExpressionParser();
@@ -17,94 +21,100 @@ namespace ParserTests
             Parser = builder.BuildParser<ExpressionToken>(parserInstance, ParserType.LL_RECURSIVE_DESCENT, "expression");
         }
 
-        [Test]
+
+        [Fact]
         public void TestSingleValue()
         {
             ParseResult<ExpressionToken> r = Parser.Parse("1");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(1, (int)r.Result);
+            Assert.Equal(1, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestSingleNegativeValue()
         {
-            ParseResult<ExpressionToken> r = Parser.Parse("-1");
+            ParseResult <ExpressionToken> r = Parser.Parse("-1");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(-1, (int)r.Result);
+            Assert.Equal(-1, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestTermPlus()
         {
             ParseResult<ExpressionToken> r = Parser.Parse("1 + 1");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(2, (int)r.Result);
+            Assert.Equal(2, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestTermMinus()
         {
             ParseResult<ExpressionToken> r = Parser.Parse("1 - 1");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(0, (int)r.Result);
+            Assert.Equal(0, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestFactorTimes()
         {
             ParseResult<ExpressionToken> r = Parser.Parse("2*2");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(4, (int)r.Result);
+            Assert.Equal(4, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestFactorDivide()
         {
             ParseResult<ExpressionToken> r = Parser.Parse("42/2");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(21, (int)r.Result);
+            Assert.Equal(21, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestGroup()
         {
             ParseResult<ExpressionToken> r = Parser.Parse("(2 + 2)");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(4, (int)r.Result);
+            Assert.Equal(4, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestGroup2()
         {
             ParseResult<ExpressionToken> r = Parser.Parse("6 * (2 + 2)");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(24, (int)r.Result);
+            Assert.Equal(24, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestPrecedence()
         {
             ParseResult<ExpressionToken> r = Parser.Parse("6 * 2 + 2");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
             Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(14, (int)r.Result);
+            Assert.Equal(14, (int)r.Result);
         }
+
+
+        
+
+      
     }
 }

--- a/ParserTests/JsonTests.cs
+++ b/ParserTests/JsonTests.cs
@@ -1,18 +1,18 @@
-﻿using System.Collections.Generic;
-using jsonparser;
-using NUnit.Framework;
+﻿using Xunit;
 using sly.parser;
 using sly.parser.generator;
+using System.Collections.Generic;
+using jsonparser;
 
 namespace ParserTests
 {
-    [TestFixture]
+    
     public class JsonTests
     {
 
         private static Parser<JsonToken> Parser;
-
-
+        
+      
         public JsonTests()
         {
             JSONParser jsonParser = new JSONParser();
@@ -20,63 +20,66 @@ namespace ParserTests
             Parser = builder.BuildParser<JsonToken>(jsonParser, ParserType.LL_RECURSIVE_DESCENT, "root");
         }
 
-        #region VALUES
-        [Test]
+        
+
+
+#region VALUES
+        [Fact]
         public void TestIntValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("1");
             Assert.False(r.IsError);
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(int), r.Result);
-            Assert.AreEqual(1, (int)r.Result);
+            Assert.IsAssignableFrom(typeof(int), r.Result);                
+            Assert.Equal(1, (int)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestDoubleValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("0.1");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(double), r.Result);
-            Assert.AreEqual(0.1d, (double)r.Result);
+            Assert.IsAssignableFrom(typeof(double),r.Result);
+            Assert.Equal(0.1d, (double)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestStringValue()
         {
             string val = "hello world!";
             ParseResult<JsonToken> r = Parser.Parse("\"" + val + "\"");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(string), r.Result);
-            Assert.AreEqual(val, (string)r.Result);
+            Assert.IsAssignableFrom(typeof(string),r.Result);
+            Assert.Equal(val, (string)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestTrueBooleanValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("true");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(bool), r.Result);
-            Assert.AreEqual(true, (bool)r.Result);
+            Assert.IsAssignableFrom(typeof(bool),r.Result);
+            Assert.Equal(true, (bool)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestFalseBooleanValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("false");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(bool), r.Result);
-            Assert.AreEqual(false, (bool)r.Result);
+            Assert.IsAssignableFrom(typeof(bool),r.Result);
+            Assert.Equal(false, (bool)r.Result);
         }
 
-        [Test]
+        [Fact]
         public void TestNullValue()
         {
-            ParseResult<JsonToken> r = Parser.Parse("null");
+            ParseResult<JsonToken> r = Parser.Parse("null");            
             Assert.False(r.IsError);
             Assert.Null(r.Result);
         }
@@ -85,30 +88,30 @@ namespace ParserTests
 
         #region OBJECT
 
-        [Test]
+        [Fact]
         public void TestEmptyObjectValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("{}");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(Dictionary<string, object>), r.Result);
-            Assert.AreEqual(0, ((Dictionary<string, object>)r.Result).Count);
+            Assert.IsAssignableFrom(typeof(Dictionary<string,object>),r.Result);
+            Assert.Equal(0, ((Dictionary<string, object>)r.Result).Count);
         }
 
 
-        [Test]
+        [Fact]
         public void TestSinglePropertyObjectValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("{\"prop\":\"value\"}");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(Dictionary<string, object>), r.Result);
+            Assert.IsAssignableFrom(typeof(Dictionary<string, object>),r.Result);
             Dictionary<string, object> values = (Dictionary<string, object>)r.Result;
             Assert.True(values.ContainsKey("prop"));
-            Assert.AreEqual("value", values["prop"]);
+            Assert.Equal("value", values["prop"]);
         }
 
-        [Test]
+        [Fact]
         public void TestManyPropertyObjectValue()
         {
             string json = "{\"p1\":\"v1\",\"p2\":\"v2\"}";
@@ -116,15 +119,15 @@ namespace ParserTests
             ParseResult<JsonToken> r = Parser.Parse(json);
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(Dictionary<string, object>), r.Result);
+            Assert.IsAssignableFrom(typeof(Dictionary<string, object>),r.Result);
             Dictionary<string, object> values = (Dictionary<string, object>)r.Result;
             Assert.True(values.ContainsKey("p1"));
-            Assert.AreEqual("v1", values["p1"]);
+            Assert.Equal("v1", values["p1"]);
             Assert.True(values.ContainsKey("p2"));
-            Assert.AreEqual("v2", values["p2"]);
+            Assert.Equal("v2", values["p2"]);
         }
 
-        [Test]
+        [Fact]
         public void TestManyNestedPropertyObjectValue()
         {
             string json = "{\"p1\":\"v1\",\"p2\":\"v2\",\"p3\":{\"inner1\":1}}";
@@ -132,61 +135,61 @@ namespace ParserTests
             ParseResult<JsonToken> r = Parser.Parse(json);
             Assert.False(r.IsError);
             Assert.NotNull(r);
-            Assert.IsAssignableFrom(typeof(Dictionary<string, object>), r.Result);
+            Assert.IsAssignableFrom(typeof(Dictionary<string, object>),r.Result);
             Dictionary<string, object> values = (Dictionary<string, object>)r.Result;
             Assert.True(values.ContainsKey("p1"));
-            Assert.AreEqual("v1", values["p1"]);
+            Assert.Equal("v1", values["p1"]);
             Assert.True(values.ContainsKey("p2"));
-            Assert.AreEqual("v2", values["p2"]);
+            Assert.Equal("v2", values["p2"]);
 
             Assert.True(values.ContainsKey("p3"));
             object inner = values["p3"];
-            Assert.IsAssignableFrom(typeof(Dictionary<string, object>), inner);
+            Assert.IsAssignableFrom(typeof(Dictionary<string, object>),inner);
             Dictionary<string, object> innerDic = (Dictionary<string, object>)inner;
-            Assert.AreEqual(1, innerDic.Count);
+            Assert.Equal(1, innerDic.Count);
             Assert.True(innerDic.ContainsKey("inner1"));
-            Assert.AreEqual(1, innerDic["inner1"]);
+            Assert.Equal(1, innerDic["inner1"]);
         }
 
         #endregion
 
 
         #region LIST
-        [Test]
+        [Fact]
         public void TestEmptyListValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("[]");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(List<object>), r.Result);
-            Assert.AreEqual(0, ((List<object>)r.Result).Count);
+            Assert.IsAssignableFrom(typeof(List<object>),r.Result);
+            Assert.Equal(0, ((List<object>)r.Result).Count);
         }
 
-        [Test]
+        [Fact]
         public void TestSingleListValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("[1]");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(List<object>), r.Result);
-            Assert.AreEqual(1, ((List<object>)r.Result).Count);
-            Assert.AreEqual(1, ((List<object>)r.Result)[0]);
+            Assert.IsAssignableFrom(typeof(List<object>),r.Result);
+            Assert.Equal(1, ((List<object>)r.Result).Count);
+            Assert.Equal(1, ((List<object>)r.Result)[0]);
 
         }
 
-        [Test]
+        [Fact]
         public void TestManyListValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("[1,2]");
             Assert.False(r.IsError);
             Assert.NotNull(r.Result);
-            Assert.IsAssignableFrom(typeof(List<object>), r.Result);
-            Assert.AreEqual(2, ((List<object>)r.Result).Count);
-            Assert.AreEqual(1, ((List<object>)r.Result)[0]);
-            Assert.AreEqual(2, ((List<object>)r.Result)[1]);
+            Assert.IsAssignableFrom(typeof(List<object>),r.Result);
+            Assert.Equal(2, ((List<object>)r.Result).Count);
+            Assert.Equal(1, ((List<object>)r.Result)[0]);
+            Assert.Equal(2, ((List<object>)r.Result)[1]);
         }
 
-        [Test]
+        [Fact]
         public void TestManyMixedListValue()
         {
             ParseResult<JsonToken> r = Parser.Parse("[1,null,{},true,42.58]");
@@ -195,15 +198,17 @@ namespace ParserTests
             Assert.NotNull(r.Result);
             object val = r.Result;
             Assert.IsAssignableFrom(typeof(List<object>), r.Result);
-            Assert.AreEqual(5, ((List<object>)r.Result).Count);
-            Assert.AreEqual(1, ((List<object>)r.Result)[0]);
+            Assert.Equal(5, ((List<object>)r.Result).Count);
+            Assert.Equal(1, ((List<object>)r.Result)[0]);
             Assert.Null(((List<object>)r.Result)[1]);
-            Assert.IsAssignableFrom(typeof(Dictionary<string, object>), ((List<object>)r.Result)[2]);
-            Assert.AreEqual(0, ((Dictionary<string, object>)(((List<object>)r.Result)[2])).Count);
-            Assert.AreEqual(true, ((List<object>)r.Result)[3]);
-            Assert.AreEqual(42.58d, ((List<object>)r.Result)[4]);
+            Assert.IsAssignableFrom(typeof(Dictionary<string, object>),((List<object>)r.Result)[2]);
+            Assert.Equal(0, ((Dictionary<string, object>)(((List<object>)r.Result)[2])).Count);
+            Assert.Equal(true, ((List<object>)r.Result)[3]);
+            Assert.Equal(42.58d, ((List<object>)r.Result)[4]);
         }
 
         #endregion
+
+       
     }
 }

--- a/ParserTests/LexerTests.cs
+++ b/ParserTests/LexerTests.cs
@@ -1,15 +1,15 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using sly.parser;
 using expressionparser;
 using jsonparser;
-using NUnit.Framework;
 using sly.lexer;
-using sly.parser;
 using sly.parser.generator;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
 
 namespace ParserTests
 {
-    [TestFixture]
     public class LexerTests
     {
 
@@ -29,13 +29,16 @@ namespace ParserTests
             return parser.Lexer;
         }
 
-        [Test]
+
+
+
+        [Fact]
         public void TestSingleLineJsonLexing()
         {
             string json = "{ \"propi\": 12 , \"props\":\"val\" }";
             ILexer<JsonToken> lexer = GetJsonLexer();
             List<Token<JsonToken>> tokens = lexer.Tokenize(json).ToList<Token<JsonToken>>();
-            Assert.AreEqual(10, tokens.Count);
+            Assert.Equal(10, tokens.Count);
             List<JsonToken> expectedTokensID = new List<JsonToken>()
             {
                 JsonToken.ACCG, JsonToken.STRING,JsonToken.COLON,JsonToken.INT,
@@ -43,7 +46,7 @@ namespace ParserTests
                 JsonToken.ACCD
             };
             List<JsonToken> tokensID = tokens.Take(9).Select((Token<JsonToken> tok) => tok.TokenID).ToList<JsonToken>();
-            Assert.AreEqual(expectedTokensID, tokensID);
+            Assert.Equal(expectedTokensID, tokensID);
 
             List<int> expectedColumnPositions = new List<int>()
             {
@@ -51,23 +54,25 @@ namespace ParserTests
             };
 
             List<int> columnPositions = tokens.Take(9).Select((Token<JsonToken> tok) => tok.Position.Column).ToList<int>();
-            Assert.AreEqual(expectedColumnPositions, columnPositions);
+            Assert.Equal(expectedColumnPositions, columnPositions);
+
+            ;
         }
 
-        [Test]
+        [Fact]
         public void TestSingleLineExpressionLexing()
         {
             ILexer<ExpressionToken> lexer = GetExpressionLexer();
         }
 
-        [Test]
+        [Fact]
         public void TestMultiLineJsonLexing()
         {
             string json = "{ \"propi\": 12 \n" +
              ", \"props\":\"val\" }";
             ILexer<JsonToken> lexer = GetJsonLexer();
             List<Token<JsonToken>> tokens = lexer.Tokenize(json).ToList<Token<JsonToken>>();
-            Assert.AreEqual(10, tokens.Count);
+            Assert.Equal(10, tokens.Count);
             List<JsonToken> expectedTokensID = new List<JsonToken>()
             {
                 JsonToken.ACCG, JsonToken.STRING,JsonToken.COLON,JsonToken.INT,
@@ -75,7 +80,7 @@ namespace ParserTests
                 JsonToken.ACCD
             };
             List<JsonToken> tokensID = tokens.Take(9).Select((Token<JsonToken> tok) => tok.TokenID).ToList<JsonToken>();
-            Assert.AreEqual(expectedTokensID, tokensID);
+            Assert.Equal(expectedTokensID, tokensID);
 
             List<int> expectedColumnPositions = new List<int>()
             {
@@ -84,7 +89,7 @@ namespace ParserTests
             };
 
             List<int> columnPositions = tokens.Take(9).Select((Token<JsonToken> tok) => tok.Position.Column).ToList<int>();
-            Assert.AreEqual(expectedColumnPositions, columnPositions);
+            Assert.Equal(expectedColumnPositions, columnPositions);
 
             List<int> expectedLinePositions = new List<int>()
             {
@@ -92,10 +97,12 @@ namespace ParserTests
             };
 
             List<int> linePositions = tokens.Take(9).Select((Token<JsonToken> tok) => tok.Position.Line).ToList<int>();
-            Assert.AreEqual(expectedLinePositions, linePositions);
+            Assert.Equal(expectedLinePositions, linePositions);
+
+            ;
         }
 
-        [Test]
+        [Fact]
         public void TestMultiLineExpressionLexing()
         {
             ILexer<ExpressionToken> lexer = GetExpressionLexer();

--- a/ParserTests/ParserTests.csproj
+++ b/ParserTests/ParserTests.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ParserTests/VisitorTests.cs
+++ b/ParserTests/VisitorTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
-using NUnit.Framework;
-using sly.lexer;
-using sly.parser;
+﻿using Xunit;
+using System.Collections.Generic;
 using sly.parser.generator;
+using sly.parser;
 using sly.parser.syntax;
+using sly.lexer;
 
 namespace ParserTests
 {
@@ -16,42 +16,40 @@ namespace ParserTests
         EOL = 101
     }
 
-    [TestFixture]
+
+   
     public class VisitorTests
     {
 
         [Production("R : A b c ")]
-        public object R(string A, Token<TokenType> b, Token<TokenType> c)
+        public  object R(string A, Token<TokenType> b, Token<TokenType> c)
         {
             string result = "R(";
             result += A + ",";
-            result += b.Value + ",";
+            result += b.Value+",";
             result += c.Value;
             result += ")";
             return result;
         }
 
         [Production("A : a ")]
-        public object A(Token<TokenType> a)
+        public  object A(Token<TokenType> a)
         {
-            string result = "A(";
-            result += a.Value;
+            string result = "A(";            
+            result += a.Value;            
             result += ")";
             return result;
         }
 
-        public SyntaxLeaf<TokenType> Leaf(TokenType typ, string value, TokenPosition position)
+        public SyntaxLeaf<TokenType> leaf(TokenType typ, string value,TokenPosition position)
         {
-            Token<TokenType> tok = new Token<TokenType>(typ, value, position)
-            {
-                TokenID = typ,
-                Value = value
-            };
-
+            Token<TokenType> tok = new Token<TokenType>(typ, value, position);
+            tok.TokenID = typ;
+            tok.Value = value;
             return new SyntaxLeaf<TokenType>(tok);
         }
 
-        public SyntaxNode<TokenType> Node(string name, params ISyntaxNode<TokenType>[] leaves)
+        public SyntaxNode<TokenType> node(string name, params ISyntaxNode<TokenType>[] leaves)
         {
             List<ISyntaxNode<TokenType>> subNodes = new List<ISyntaxNode<TokenType>>();
             subNodes.AddRange(leaves);
@@ -59,8 +57,8 @@ namespace ParserTests
             return n;
         }
 
-        [Test]
-        public void TestVisitor()
+        [Fact]
+        public void testVisitor()
         {
             VisitorTests visitorInstance = new VisitorTests();
             ParserBuilder builder = new ParserBuilder();
@@ -70,16 +68,18 @@ namespace ParserTests
             // build a syntax tree
 
             TokenPosition position = new TokenPosition(0, 1, 1);
-            SyntaxLeaf<TokenType> aT = Leaf(TokenType.a, "a", position);
-            SyntaxLeaf<TokenType> bT = Leaf(TokenType.b, "b", position);
-            SyntaxLeaf<TokenType> cT = Leaf(TokenType.c, "c", position);
+            SyntaxLeaf<TokenType> aT = leaf(TokenType.a, "a", position);
+            SyntaxLeaf<TokenType> bT = leaf(TokenType.b, "b", position);
+            SyntaxLeaf<TokenType> cT = leaf(TokenType.c, "c", position);
 
-            SyntaxNode<TokenType> aN = Node("A__a_", aT);
-            SyntaxNode<TokenType> rN = Node("R__A_b_c", aN, bT, cT);
+            SyntaxNode<TokenType> aN = node("A__a_", aT);
+            SyntaxNode<TokenType> rN = node("R__A_b_c", aN,bT,cT);
 
             string r = visitor.VisitSyntaxTree(rN).ToString();
+            ;
+            Assert.Equal("R(A(a),b,c)", r);            
 
-            Assert.AreEqual("R(A(a),b,c)", r);
+
         }
     }
 }

--- a/sly/sly.csproj
+++ b/sly/sly.csproj
@@ -8,14 +8,9 @@
 	<RepositoryUrl>https://github.com/b3b00/csly</RepositoryUrl>
 	<PackageLicenseUrl>https://github.com/b3b00/csly/blob/master/LICENSE</PackageLicenseUrl>    
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
-    <LangVersion>6</LangVersion>
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile></DocumentationFile>
-    <LangVersion>6</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Reverts b3b00/csly#22
appVeyor CI has no direct support for NUnit unit tests (it does not display the tests results in the tests tab as it does with xunit.  The only reason to switch to NUnit is to have a Mac V2017 support which far less important than a correctly working CI.

