### PR TITLE
Upgrade SourceLink to version 1.0.0-beta2-19554-01.

### DIFF
--- a/sly/sly.csproj
+++ b/sly/sly.csproj
@@ -24,7 +24,7 @@
      <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
I'm trying to build on Ubuntu 19.10. This fails with
```
error MSB4018: System.TypeInitializationException: The type initializer for 'LibGit2Sharp.Core.NativeMethods' threw an exception.
error MSB4018:  ---> System.DllNotFoundException: Unable to load shared library 'xxx/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta-62925-02/build/../tools/netcoreapp2.0/runtimes/linux-x64/native/libgit2-6311e88.so' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: libssl.so.1.0.0: cannot open shared object file: No such file or directory
```

This is a well-known error on Ubuntu >= 18.04 (10?), which upgraded from curl3 to curl4, and is caused by bad versioning of the open ssl library.

Upgrading SourceLink to version 1.0.0-beta2-19554-01 seems to solve this problem.