### PR TITLE
Lexer configuration

### DIFF
--- a/ParserTests/lexer/GenericLexerTests.cs
+++ b/ParserTests/lexer/GenericLexerTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Linq;
+using GenericLexerWithCallbacks;
 using sly.buildresult;
 using sly.lexer;
 using sly.lexer.fsm;
 using Xunit;
-using GenericLexerWithCallbacks;
 
 namespace ParserTests.lexer
 {
@@ -174,6 +174,19 @@ namespace ParserTests.lexer
         ID
     }
 
+    public enum KeyWord
+    {
+        [Lexeme(GenericToken.KeyWord, "keyword")]
+        KEYWORD = 1
+    }
+
+    [Lexer(KeyWordIgnoreCase = true)]
+    public enum KeyWordIgnoreCase
+    {
+        [Lexeme(GenericToken.KeyWord, "keyword")]
+        KEYWORD = 1
+    }
+
     public enum Issue106
     {
         [Lexeme(GenericToken.Int)]
@@ -318,7 +331,41 @@ namespace ParserTests.lexer
             Assert.Equal(2, r.Tokens.Count);
             var tok = r.Tokens[0];
             Assert.Equal(WhiteSpace.TAB, tok.TokenID);
-            Assert.Equal("\t", tok.StringWithoutQuotes);
+            Assert.Equal("\t",           tok.StringWithoutQuotes);
+        }
+
+        [Fact]
+        public void TestKeyWord()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<KeyWord>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize("keyword KeYwOrD");
+            Assert.True(r.IsOk);
+            Assert.Equal(3, r.Tokens.Count);
+            var tok1 = r.Tokens[0];
+            Assert.Equal(KeyWord.KEYWORD, tok1.TokenID);
+            Assert.Equal("keyword",       tok1.StringWithoutQuotes);
+            var tok2 = r.Tokens[1];
+            Assert.Equal(default(KeyWord), tok2.TokenID);
+            Assert.Equal("KeYwOrD",        tok2.StringWithoutQuotes);
+        }
+
+        [Fact]
+        public void TestKeyWordIgnoreCase()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<KeyWordIgnoreCase>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize("keyword KeYwOrD");
+            Assert.True(r.IsOk);
+            Assert.Equal(3, r.Tokens.Count);
+            var tok1 = r.Tokens[0];
+            Assert.Equal(KeyWordIgnoreCase.KEYWORD, tok1.TokenID);
+            Assert.Equal("keyword",                 tok1.StringWithoutQuotes);
+            var tok2 = r.Tokens[1];
+            Assert.Equal(KeyWordIgnoreCase.KEYWORD, tok2.TokenID);
+            Assert.Equal("KeYwOrD",                 tok2.StringWithoutQuotes);
         }
 
         [Fact]

--- a/ParserTests/lexer/GenericLexerTests.cs
+++ b/ParserTests/lexer/GenericLexerTests.cs
@@ -163,7 +163,15 @@ namespace ParserTests.lexer
     public enum WhiteSpace
     {
         [Lexeme(GenericToken.SugarToken, "\t")]
-        TAB
+        TAB 
+    }
+
+    public enum Empty
+    {
+        EOS,
+        
+        [Lexeme(GenericToken.Identifier)]
+        ID
     }
 
     public enum Issue106
@@ -186,6 +194,34 @@ namespace ParserTests.lexer
 
     public class GenericLexerTests
     {
+        [Fact]
+        public void TestEmptyInput()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<Empty>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize("");
+            Assert.True(r.IsOk);
+            Assert.Single(r.Tokens);
+            var tok = r.Tokens[0];
+            Assert.Equal(Empty.EOS, tok.TokenID);
+            Assert.Equal("",        tok.StringWithoutQuotes);
+        }
+
+        [Fact]
+        public void TestIgnoredInput()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<Empty>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize(" \t\n ");
+            Assert.True(r.IsOk);
+            Assert.Single(r.Tokens);
+            var tok = r.Tokens[0];
+            Assert.Equal(Empty.EOS, tok.TokenID);
+            Assert.Equal("",        tok.StringWithoutQuotes);
+        }
+
         [Fact]
         public void TestAlphaId()
         {

--- a/ParserTests/lexer/GenericLexerTests.cs
+++ b/ParserTests/lexer/GenericLexerTests.cs
@@ -145,6 +145,17 @@ namespace ParserTests.lexer
         ID
     }
 
+    public enum CustomId
+    {
+        EOS,
+        
+        [Lexeme(GenericToken.Identifier, IdentifierType.Custom, "A-Za-z", "-_0-9A-Za-z")]
+        ID,
+        
+        [Lexeme(GenericToken.SugarToken, "-", "_")]
+        OTHER
+    }
+
     [Lexer(IgnoreWS = false)]
     public enum IgnoreWS
     {
@@ -218,7 +229,7 @@ namespace ParserTests.lexer
             Assert.Single(r.Tokens);
             var tok = r.Tokens[0];
             Assert.Equal(Empty.EOS, tok.TokenID);
-            Assert.Equal("",        tok.StringWithoutQuotes);
+            Assert.Equal("",        tok.Value);
         }
 
         [Fact]
@@ -232,7 +243,7 @@ namespace ParserTests.lexer
             Assert.Single(r.Tokens);
             var tok = r.Tokens[0];
             Assert.Equal(Empty.EOS, tok.TokenID);
-            Assert.Equal("",        tok.StringWithoutQuotes);
+            Assert.Equal("",        tok.Value);
         }
 
         [Fact]
@@ -293,6 +304,46 @@ namespace ParserTests.lexer
         }
 
         [Fact]
+        public void TestCustomId()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<CustomId>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize("a_-Bc ZyX-_");
+            Assert.True(r.IsOk);
+            Assert.Equal(3, r.Tokens.Count);
+            var tok1 = r.Tokens[0];
+            Assert.Equal(CustomId.ID, tok1.TokenID);
+            Assert.Equal("a_-Bc",     tok1.Value);
+            var tok2 = r.Tokens[1];
+            Assert.Equal(CustomId.ID, tok2.TokenID);
+            Assert.Equal("ZyX-_",     tok2.Value);
+        }
+
+        [Fact]
+        public void TestCustomIdWithOther()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<CustomId>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize("_b_ -C-");
+            Assert.True(r.IsOk);
+            Assert.Equal(5, r.Tokens.Count);
+            var tok1 = r.Tokens[0];
+            Assert.Equal(CustomId.OTHER, tok1.TokenID);
+            Assert.Equal("_",            tok1.Value);
+            var tok2 = r.Tokens[1];
+            Assert.Equal(CustomId.ID, tok2.TokenID);
+            Assert.Equal("b_",        tok2.Value);
+            var tok3 = r.Tokens[2];
+            Assert.Equal(CustomId.OTHER, tok3.TokenID);
+            Assert.Equal("-",            tok3.Value);
+            var tok4 = r.Tokens[3];
+            Assert.Equal(CustomId.ID, tok4.TokenID);
+            Assert.Equal("C-",        tok4.Value);
+        }
+
+        [Fact]
         public void TestIgnoreWS()
         {
             var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<IgnoreWS>>());
@@ -303,7 +354,7 @@ namespace ParserTests.lexer
             Assert.Equal(2, r.Tokens.Count);
             var tok = r.Tokens[0];
             Assert.Equal(IgnoreWS.WS, tok.TokenID);
-            Assert.Equal(" ", tok.StringWithoutQuotes);
+            Assert.Equal(" ", tok.Value);
         }
 
         [Fact]
@@ -317,7 +368,7 @@ namespace ParserTests.lexer
             Assert.Equal(2, r.Tokens.Count);
             var tok = r.Tokens[0];
             Assert.Equal(IgnoreEOL.EOL, tok.TokenID);
-            Assert.Equal("\n", tok.StringWithoutQuotes);
+            Assert.Equal("\n", tok.Value);
         }
 
         [Fact]
@@ -331,7 +382,7 @@ namespace ParserTests.lexer
             Assert.Equal(2, r.Tokens.Count);
             var tok = r.Tokens[0];
             Assert.Equal(WhiteSpace.TAB, tok.TokenID);
-            Assert.Equal("\t",           tok.StringWithoutQuotes);
+            Assert.Equal("\t",           tok.Value);
         }
 
         [Fact]
@@ -345,10 +396,10 @@ namespace ParserTests.lexer
             Assert.Equal(3, r.Tokens.Count);
             var tok1 = r.Tokens[0];
             Assert.Equal(KeyWord.KEYWORD, tok1.TokenID);
-            Assert.Equal("keyword",       tok1.StringWithoutQuotes);
+            Assert.Equal("keyword",       tok1.Value);
             var tok2 = r.Tokens[1];
             Assert.Equal(default(KeyWord), tok2.TokenID);
-            Assert.Equal("KeYwOrD",        tok2.StringWithoutQuotes);
+            Assert.Equal("KeYwOrD",        tok2.Value);
         }
 
         [Fact]
@@ -362,10 +413,10 @@ namespace ParserTests.lexer
             Assert.Equal(3, r.Tokens.Count);
             var tok1 = r.Tokens[0];
             Assert.Equal(KeyWordIgnoreCase.KEYWORD, tok1.TokenID);
-            Assert.Equal("keyword",                 tok1.StringWithoutQuotes);
+            Assert.Equal("keyword",                 tok1.Value);
             var tok2 = r.Tokens[1];
             Assert.Equal(KeyWordIgnoreCase.KEYWORD, tok2.TokenID);
-            Assert.Equal("KeYwOrD",                 tok2.StringWithoutQuotes);
+            Assert.Equal("KeYwOrD",                 tok2.Value);
         }
 
         [Fact]

--- a/ParserTests/lexer/GenericLexerTests.cs
+++ b/ParserTests/lexer/GenericLexerTests.cs
@@ -145,6 +145,27 @@ namespace ParserTests.lexer
         ID
     }
 
+    [Lexer(IgnoreWS = false)]
+    public enum IgnoreWS
+    {
+        [Lexeme(GenericToken.SugarToken, " ")]
+        WS
+    }
+
+    [Lexer(IgnoreEOL = false)]
+    public enum IgnoreEOL
+    {
+        [Lexeme(GenericToken.SugarToken, "\n")]
+        EOL
+    }
+
+    [Lexer(WhiteSpace = new[] { ' ' })]
+    public enum WhiteSpace
+    {
+        [Lexeme(GenericToken.SugarToken, "\t")]
+        TAB
+    }
+
     public enum Issue106
     {
         [Lexeme(GenericToken.Int)]
@@ -220,6 +241,48 @@ namespace ParserTests.lexer
             var tok = r.Tokens[0];
             Assert.Equal(AlphaNumId.ID, tok.TokenID);
             Assert.Equal("alpha123", tok.StringWithoutQuotes);
+        }
+
+        [Fact]
+        public void TestIgnoreWS()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<IgnoreWS>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize("\n \n");
+            Assert.True(r.IsOk);
+            Assert.Equal(2, r.Tokens.Count);
+            var tok = r.Tokens[0];
+            Assert.Equal(IgnoreWS.WS, tok.TokenID);
+            Assert.Equal(" ", tok.StringWithoutQuotes);
+        }
+
+        [Fact]
+        public void TestIgnoreEOL()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<IgnoreEOL>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize(" \n ");
+            Assert.True(r.IsOk);
+            Assert.Equal(2, r.Tokens.Count);
+            var tok = r.Tokens[0];
+            Assert.Equal(IgnoreEOL.EOL, tok.TokenID);
+            Assert.Equal("\n", tok.StringWithoutQuotes);
+        }
+
+        [Fact]
+        public void TestWhiteSpace()
+        {
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<WhiteSpace>>());
+            Assert.False(lexerRes.IsError);
+            var lexer = lexerRes.Result;
+            var r = lexer.Tokenize(" \t ");
+            Assert.True(r.IsOk);
+            Assert.Equal(2, r.Tokens.Count);
+            var tok = r.Tokens[0];
+            Assert.Equal(WhiteSpace.TAB, tok.TokenID);
+            Assert.Equal("\t", tok.StringWithoutQuotes);
         }
 
         [Fact]

--- a/sly/buildresult/BuildResult.cs
+++ b/sly/buildresult/BuildResult.cs
@@ -6,8 +6,7 @@ namespace sly.buildresult
     public class BuildResult<R>
     {
         public BuildResult() : this(default(R))
-        {
-        }
+        { }
 
         public BuildResult(R result)
         {
@@ -15,15 +14,13 @@ namespace sly.buildresult
             Errors = new List<InitializationError>();
         }
 
-        public List<InitializationError> Errors { get; set; }
+        public List<InitializationError> Errors { get; }
 
         public R Result { get; set; }
 
-
         public bool IsError
         {
-            get { return Errors.Where(e => e.Level != ErrorLevel.WARN).Any(); }
-            set { }
+            get { return Errors.Any(e => e.Level != ErrorLevel.WARN); }
         }
 
         public bool IsOk => !IsError;

--- a/sly/lexer/GenericLexer.cs
+++ b/sly/lexer/GenericLexer.cs
@@ -170,9 +170,16 @@ namespace sly.lexer
             }
 
             var eos = new Token<IN>();
-            var prev = tokens.Last();
-            eos.Position = new TokenPosition(prev.Position.Index + 1, prev.Position.Line,
-                prev.Position.Column + prev.Value.Length);
+            var prev = tokens.LastOrDefault();
+            if (prev == null)
+            {
+                eos.Position = new TokenPosition(1, 0, 0);
+            }
+            else
+            {
+                eos.Position = new TokenPosition(prev.Position.Index + 1, prev.Position.Line,
+                    prev.Position.Column + prev.Value.Length);
+            }
             tokens.Add(eos);
             return new LexerResult<IN>(tokens);
         }

--- a/sly/lexer/LexemeAttribute.cs
+++ b/sly/lexer/LexemeAttribute.cs
@@ -37,7 +37,10 @@ namespace sly.lexer
         public bool IsLineEnding { get; set; }
 
 
-        public bool IsStaticGeneric => (GenericTokenParameters == null || GenericTokenParameters.Length == 0) &&
+        public bool HasGenericTokenParameters => GenericTokenParameters != null && GenericTokenParameters.Length > 0;
+
+        // TODO Should GenericToken.Char be excluded from static generic also?
+        public bool IsStaticGeneric => !HasGenericTokenParameters &&
                                        GenericToken != GenericToken.String && GenericToken != GenericToken.Extension;
 
         public bool IsKeyWord => GenericToken == GenericToken.KeyWord;

--- a/sly/lexer/LexemeAttribute.cs
+++ b/sly/lexer/LexemeAttribute.cs
@@ -18,10 +18,15 @@ namespace sly.lexer
             GenericTokenParameters = parameters;
         }
 
-        public LexemeAttribute(GenericToken generic, IdentifierType idType)
+        public LexemeAttribute(GenericToken generic, IdentifierType idType, string startPattern = null, string restPattern = null)
         {
             GenericToken = generic;
             IdentifierType = idType;
+            if (idType == IdentifierType.Custom)
+            {
+                IdentifierStartPattern = startPattern ?? throw new ArgumentNullException(nameof(startPattern));
+                IdentifierRestPattern = restPattern ?? startPattern;
+            }
         }
 
         public GenericToken GenericToken { get; set; }
@@ -29,6 +34,10 @@ namespace sly.lexer
         public string[] GenericTokenParameters { get; set; }
 
         public IdentifierType IdentifierType { get; set; } = IdentifierType.Alpha;
+        
+        public string IdentifierStartPattern { get; }
+        
+        public string IdentifierRestPattern { get; }
 
         public string Pattern { get; set; }
 

--- a/sly/lexer/LexerAttribute.cs
+++ b/sly/lexer/LexerAttribute.cs
@@ -13,6 +13,8 @@ namespace sly.lexer
 
         private char[] whiteSpace;
 
+        private bool? keyWordIgnoreCase;
+
         public bool IgnoreWS
         {
             get => ignoreWS ?? Defaults.IgnoreWS;
@@ -29,6 +31,12 @@ namespace sly.lexer
         {
             get => whiteSpace ?? Defaults.WhiteSpace;
             set => whiteSpace = value;
+        }
+
+        public bool KeyWordIgnoreCase
+        {
+            get => keyWordIgnoreCase ?? Defaults.KeyWordIgnoreCase;
+            set => keyWordIgnoreCase = value;
         }
     }
 }

--- a/sly/lexer/LexerAttribute.cs
+++ b/sly/lexer/LexerAttribute.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace sly.lexer
+{
+    [AttributeUsage(AttributeTargets.Enum)]
+    public class LexerAttribute : Attribute
+    {
+        private static readonly GenericLexer<int>.Config Defaults = new GenericLexer<int>.Config();
+
+        private bool? ignoreWS;
+
+        private bool? ignoreEOL;
+
+        private char[] whiteSpace;
+
+        public bool IgnoreWS
+        {
+            get => ignoreWS ?? Defaults.IgnoreWS;
+            set => ignoreWS = value;
+        }
+
+        public bool IgnoreEOL
+        {
+            get => ignoreEOL ?? Defaults.IgnoreEOL;
+            set => ignoreEOL = value;
+        }
+
+        public char[] WhiteSpace
+        {
+            get => whiteSpace ?? Defaults.WhiteSpace;
+            set => whiteSpace = value;
+        }
+    }
+}

--- a/sly/lexer/LexerBuilder.cs
+++ b/sly/lexer/LexerBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using sly.buildresult;
 using sly.lexer.fsm;
 
@@ -14,20 +13,15 @@ namespace sly.lexer
         /// </summary>
         /// <typeparam name="T">The type of the attribute you want to retrieve</typeparam>
         /// <param name="enumVal">The enum value</param>
-        /// <returns>The attributes of type T that exist on the enum value</returns>
-        /// <example>var attrs = myEnumVariable.GetAttributeOfType<DescriptionAttribute>().Description;</example>
-        public static List<T> GetAttributesOfType<T>(this Enum enumVal) where T : Attribute
+        /// <returns>The attributes of type T that exist on the enum value, or an empty array if no such attributes are found.</returns>
+        /// <example>var attrs = myEnumVariable.GetAttributesOfType&lt;DescriptionAttribute&gt;();</example>
+        public static T[] GetAttributesOfType<T>(this Enum enumVal) where T : Attribute
         {
             var type = enumVal.GetType();
             var memInfo = type.GetMember(enumVal.ToString());
-            var attributes = (IEnumerable<T>) memInfo[0].GetCustomAttributes(typeof(T), false);
+            var attributes = (T[]) memInfo[0].GetCustomAttributes(typeof(T), false);
 
-            if (attributes.Any())
-            {
-                return attributes.ToList();
-            }
-
-            return new List<T>();
+            return attributes;
         }
     }
 
@@ -35,33 +29,22 @@ namespace sly.lexer
     {
         public static Dictionary<IN, List<LexemeAttribute>> GetLexemes<IN>(BuildResult<ILexer<IN>> result) where IN: struct
         {
-            var values = Enum.GetValues(typeof(IN));
-
             var attributes = new Dictionary<IN, List<LexemeAttribute>>();
 
-            var fields = typeof(IN).GetFields();
+            var values = Enum.GetValues(typeof(IN));
             foreach (Enum value in values)
             {
                 var tokenID = (IN) (object) value;
-                var enumattributes = value.GetAttributesOfType<LexemeAttribute>();
-                if (enumattributes == null || enumattributes.Count == 0)
+                var enumAttributes = value.GetAttributesOfType<LexemeAttribute>();
+                if (enumAttributes.Length == 0)
+                {
                     result?.AddError(new LexerInitializationError(ErrorLevel.WARN,
                         $"token {tokenID} in lexer definition {typeof(IN).FullName} does not have Lexeme"));
+                }
                 else
-                    foreach (var lexem in enumattributes)
-                        if (lexem != null)
-                        {
-                            var lex = new List<LexemeAttribute>();
-                            if (attributes.ContainsKey(tokenID)) lex = attributes[tokenID];
-                            lex.Add(lexem);
-                            attributes[tokenID] = lex;
-                        }
-                        else
-                        {
-                            if (!tokenID.Equals(default(IN)))
-                                result?.AddError(new LexerInitializationError(ErrorLevel.WARN,
-                                    $"token {tokenID} in lexer definition {typeof(IN).FullName} does not have Lexeme"));
-                        }
+                {
+                    attributes[tokenID] = enumAttributes.ToList();
+                }
             }
 
             return attributes;
@@ -71,11 +54,6 @@ namespace sly.lexer
         public static BuildResult<ILexer<IN>> BuildLexer<IN>(BuildResult<ILexer<IN>> result,
             BuildExtension<IN> extensionBuilder = null) where IN : struct
         {
-            var type = typeof(IN);
-            var typeInfo = type.GetTypeInfo();
-            ILexer<IN> lexer = new Lexer<IN>();
-
-
             var attributes = GetLexemes(result);
 
             result = Build(attributes, result, extensionBuilder);
@@ -87,20 +65,24 @@ namespace sly.lexer
         private static BuildResult<ILexer<IN>> Build<IN>(Dictionary<IN, List<LexemeAttribute>> attributes,
             BuildResult<ILexer<IN>> result, BuildExtension<IN> extensionBuilder = null) where IN : struct
         {
-            var hasRegexLexem = IsRegexLexer(attributes);
-            var hasGenericLexem = IsGenericLexer(attributes);
+            var hasRegexLexemes = IsRegexLexer(attributes);
+            var hasGenericLexemes = IsGenericLexer(attributes);
 
-            if (hasGenericLexem && hasRegexLexem)
+            if (hasGenericLexemes && hasRegexLexemes)
             {
                 result.AddError(new LexerInitializationError(ErrorLevel.WARN,
                     "cannot mix Regex lexemes and Generic lexemes in same lexer"));
-                result.IsError = true;
             }
             else
             {
-                if (hasRegexLexem)
+                if (hasRegexLexemes)
+                {
                     result = BuildRegexLexer(attributes, result);
-                else if (hasGenericLexem) result = BuildGenericLexer(attributes, extensionBuilder, result);
+                }
+                else if (hasGenericLexemes)
+                {
+                    result = BuildGenericLexer(attributes, extensionBuilder, result);
+                }
             }
 
             return result;
@@ -108,56 +90,36 @@ namespace sly.lexer
 
         private static bool IsRegexLexer<IN>(Dictionary<IN, List<LexemeAttribute>> attributes)
         {
-            var isGeneric = false;
-            foreach (var ls in attributes)
-            {
-                foreach (var l in ls.Value)
-                {
-                    isGeneric = !string.IsNullOrEmpty(l.Pattern);
-                    if (isGeneric) break;
-                }
-
-                if (isGeneric) break;
-            }
-
-            return isGeneric;
+            return attributes.Values.SelectMany(list => list)
+                             .Any(lexeme => !string.IsNullOrEmpty(lexeme.Pattern));
         }
 
         private static bool IsGenericLexer<IN>(Dictionary<IN, List<LexemeAttribute>> attributes)
         {
-            var isRegex = false;
-            foreach (var ls in attributes)
-            {
-                foreach (var l in ls.Value)
-                {
-                    isRegex = l.GenericToken != default(GenericToken);
-                    if (isRegex) break;
-                }
-
-                if (isRegex) break;
-            }
-
-            return isRegex;
+            return attributes.Values.SelectMany(list => list)
+                             .Any(lexeme => lexeme.GenericToken != default(GenericToken));
         }
 
 
         private static BuildResult<ILexer<IN>> BuildRegexLexer<IN>(Dictionary<IN, List<LexemeAttribute>> attributes,
             BuildResult<ILexer<IN>> result) where IN : struct
         {
-            ILexer<IN> lexer = new Lexer<IN>();
+            var lexer = new Lexer<IN>();
             foreach (var pair in attributes)
             {
                 var tokenID = pair.Key;
 
-                var lexems = pair.Value;
+                var lexemes = pair.Value;
 
-                if (lexems != null)
+                if (lexemes != null)
                 {
                     try
                     {
-                        foreach (var lexem in lexems)
-                            lexer.AddDefinition(new TokenDefinition<IN>(tokenID, lexem.Pattern, lexem.IsSkippable,
-                                lexem.IsLineEnding));
+                        foreach (var lexeme in lexemes)
+                        {
+                            lexer.AddDefinition(new TokenDefinition<IN>(tokenID, lexeme.Pattern, lexeme.IsSkippable,
+                                lexeme.IsLineEnding));
+                        }
                     }
                     catch (Exception e)
                     {
@@ -165,11 +127,10 @@ namespace sly.lexer
                             $"error at lexem {tokenID} : {e.Message}"));
                     }
                 }
-                else
+                else if (!tokenID.Equals(default(IN)))
                 {
-                    if (!tokenID.Equals(default(IN)))
-                        result.AddError(new LexerInitializationError(ErrorLevel.WARN,
-                            $"token {tokenID} in lexer definition {typeof(IN).FullName} does not have"));
+                    result.AddError(new LexerInitializationError(ErrorLevel.WARN,
+                        $"token {tokenID} in lexer definition {typeof(IN).FullName} does not have Lexeme"));
                 }
             }
 
@@ -177,105 +138,89 @@ namespace sly.lexer
             return result;
         }
 
-        private static (List<GenericToken> tokens, IdentifierType idType) GetGenericTokensAndIdentifierType<IN>(
+        private static (GenericToken[] tokens, IdentifierType idType) GetGenericTokensAndIdentifierType<IN>(
             Dictionary<IN, List<LexemeAttribute>> attributes)
         {
-            (List<GenericToken> tokens, IdentifierType idType)
-                result = (new List<GenericToken>(), IdentifierType.Alpha);
             var statics = new List<GenericToken>();
-            foreach (var ls in attributes)
-            foreach (var l in ls.Value)
+            var idType = IdentifierType.Alpha;
+            foreach (var lexeme in attributes.Values.SelectMany(list => list))
             {
-                statics.Add(l.GenericToken);
-                if (l.IsIdentifier) result.idType = l.IdentifierType;
+                statics.Add(lexeme.GenericToken);
+                if (lexeme.IsIdentifier)
+                {
+                    idType = lexeme.IdentifierType;
+                }
             }
 
-            statics.Distinct();
-            result.tokens = statics;
-
-            return result;
+            return (statics.Distinct().ToArray(), idType);
         }
 
         private static BuildResult<ILexer<IN>> BuildGenericLexer<IN>(Dictionary<IN, List<LexemeAttribute>> attributes,
             BuildExtension<IN> extensionBuilder, BuildResult<ILexer<IN>> result) where IN : struct
         {
             result = CheckStringAndCharTokens(attributes, result);
-            var statics = GetGenericTokensAndIdentifierType(attributes);
+            var (tokens, idType) = GetGenericTokensAndIdentifierType(attributes);
             var Extensions = new Dictionary<IN, LexemeAttribute>();
-            var lexer = new GenericLexer<IN>(statics.idType, extensionBuilder, statics.tokens.ToArray());
+            var lexer = new GenericLexer<IN>(idType, extensionBuilder, tokens);
             foreach (var pair in attributes)
             {
                 var tokenID = pair.Key;
 
-                var lexems = pair.Value;
-                foreach (var lexem in lexems)
+                var lexemes = pair.Value;
+                foreach (var lexeme in lexemes)
                 {
-                    if (lexem.IsStaticGeneric) lexer.AddLexeme(lexem.GenericToken, tokenID);
-                    if (lexem.IsKeyWord)
-                        foreach (var param in lexem.GenericTokenParameters)
-                            lexer.AddKeyWord(tokenID, param);
-                    if (lexem.IsSugar)
-                        foreach (var param in lexem.GenericTokenParameters)
-                            lexer.AddSugarLexem(tokenID, param);
-                    if (lexem.IsString)
+                    try
                     {
-                        if (lexem.GenericTokenParameters != null && lexem.GenericTokenParameters.Length > 0)
-                            try
-                            {
-                                var delimiter = lexem.GenericTokenParameters[0];
-                                if (lexem.GenericTokenParameters.Length > 1)
-                                {
-                                    var escape = lexem.GenericTokenParameters[1];
-                                    lexer.AddStringLexem(tokenID, delimiter, escape);
-                                }
-                                else
-                                {
-                                    lexer.AddStringLexem(tokenID, delimiter);
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                result.IsError = true;
-                                result.AddError(new InitializationError(ErrorLevel.FATAL, e.Message+ " \n "+e.StackTrace));
-                            }
-                        else
-                            lexer.AddStringLexem(tokenID, "\"");
-                    }
-                    if (lexem.IsChar) {
-                        if (lexem.GenericTokenParameters != null && lexem.GenericTokenParameters.Length > 0)
-                            try
-                            {
-                                var delimiter = lexem.GenericTokenParameters[0];
-                                if (lexem.GenericTokenParameters.Length > 1)
-                                {
-                                    var escape = lexem.GenericTokenParameters[1];
-                                    lexer.AddCharLexem(tokenID, delimiter, escape);
-                                }
-                                else
-                                {
-                                    lexer.AddCharLexem(tokenID, delimiter);
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                result.IsError = true;
-                                result.AddError(new InitializationError(ErrorLevel.FATAL, e.Message));
-                            }
-                        else
-                            lexer.AddCharLexem(tokenID, "'");
-                    }
+                        if (lexeme.IsStaticGeneric)
+                        {
+                            lexer.AddLexeme(lexeme.GenericToken, tokenID);
+                        }
 
-                    if (lexem.IsExtension) Extensions[tokenID] = lexem;
+                        if (lexeme.IsKeyWord)
+                        {
+                            foreach (var param in lexeme.GenericTokenParameters)
+                            {
+                                lexer.AddKeyWord(tokenID, param);
+                            }
+                        }
+
+                        if (lexeme.IsSugar)
+                        {
+                            foreach (var param in lexeme.GenericTokenParameters)
+                            {
+                                lexer.AddSugarLexem(tokenID, param);
+                            }
+                        }
+
+                        if (lexeme.IsString)
+                        {
+                            var (delimiter, escape) = GetDelimiters(lexeme, "\"", "\\");
+                            lexer.AddStringLexem(tokenID, delimiter, escape);
+                        }
+
+                        if (lexeme.IsChar)
+                        {
+                            var (delimiter, escape) = GetDelimiters(lexeme, "'", "\\");
+                            lexer.AddCharLexem(tokenID, delimiter, escape);
+                        }
+
+                        if (lexeme.IsExtension)
+                        {
+                            Extensions[tokenID] = lexeme;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        result.AddError(new InitializationError(ErrorLevel.FATAL, e.Message));
+                    }
                 }
-
-
-                AddExtensions(Extensions, extensionBuilder, lexer);
             }
 
+            AddExtensions(Extensions, extensionBuilder, lexer);
 
             var comments = GetCommentsAttribute(result);
-
             if (!result.IsError)
+            {
                 foreach (var comment in comments)
                 {
                     NodeCallback<GenericToken> callbackSingle = match =>
@@ -296,24 +241,13 @@ namespace sly.lexer
 
                     foreach (var commentAttr in comment.Value)
                     {
-                        bool hasSingleLine = !string.IsNullOrWhiteSpace(commentAttr.SingleLineCommentStart);
-                        bool hasMultiLine = !string.IsNullOrWhiteSpace(commentAttr.MultiLineCommentStart);
+                        var fsmBuilder = lexer.FSMBuilder;
 
+                        var hasSingleLine = !string.IsNullOrWhiteSpace(commentAttr.SingleLineCommentStart);
                         if (hasSingleLine)
                         {
                             lexer.SingleLineComment = commentAttr.SingleLineCommentStart;
-                        }
 
-                        if (hasMultiLine)
-                        {
-                            lexer.MultiLineCommentStart = commentAttr.MultiLineCommentStart;
-                            lexer.MultiLineCommentEnd = commentAttr.MultiLineCommentEnd;
-                        }
-
-                        var fsmBuilder = lexer.FSMBuilder;
-
-                        if (hasSingleLine)
-                        {
                             fsmBuilder.GoTo(GenericLexer<IN>.start);
                             fsmBuilder.ConstantTransition(commentAttr.SingleLineCommentStart);
                             fsmBuilder.Mark(GenericLexer<IN>.single_line_comment_start);
@@ -321,8 +255,12 @@ namespace sly.lexer
                             fsmBuilder.CallBack(callbackSingle);
                         }
 
+                        var hasMultiLine = !string.IsNullOrWhiteSpace(commentAttr.MultiLineCommentStart);
                         if (hasMultiLine)
                         {
+                            lexer.MultiLineCommentStart = commentAttr.MultiLineCommentStart;
+                            lexer.MultiLineCommentEnd = commentAttr.MultiLineCommentEnd;
+                            
                             fsmBuilder.GoTo(GenericLexer<IN>.start);
                             fsmBuilder.ConstantTransition(commentAttr.MultiLineCommentStart);
                             fsmBuilder.Mark(GenericLexer<IN>.multi_line_comment_start);
@@ -331,41 +269,44 @@ namespace sly.lexer
                         }
                     }
                 }
-
-
+            }
+            
             result.Result = lexer;
             return result;
         }
-        
+
+        private static (string delimiter, string escape) GetDelimiters(LexemeAttribute lexeme, string delimiter, string escape)
+        {
+            if (lexeme.HasGenericTokenParameters)
+            {
+                delimiter = lexeme.GenericTokenParameters[0];
+                if (lexeme.GenericTokenParameters.Length > 1)
+                {
+                    escape = lexeme.GenericTokenParameters[1];
+                }
+            }
+
+            return (delimiter, escape);
+        }
+
         private static BuildResult<ILexer<IN>> CheckStringAndCharTokens<IN>(
             Dictionary<IN, List<LexemeAttribute>> attributes, BuildResult<ILexer<IN>> result) where IN : struct
         {
             var allLexemes = attributes.Values.SelectMany(a => a);
-            var charLexemes = allLexemes.Where(a => a.IsChar);
-            var stringLexems = allLexemes.Where(a => a.IsString);
 
-            var allDelimiters = allLexemes.Where(a => a.IsString || a.IsChar).Select(a =>
-            {
+            var allDelimiters = allLexemes
+                                .Where(a => a.IsString || a.IsChar)
+                                .Where(a => a.HasGenericTokenParameters)
+                                .Select(a => a.GenericTokenParameters[0]);
 
-                if (a.GenericTokenParameters != null && a.GenericTokenParameters.Any())
-                {
-                    return a.GenericTokenParameters[0];
-                }
-
-                return null;
-            }).ToList();
-
-            var doublons = allDelimiters.GroupBy(x => x)
+            var duplicates = allDelimiters.GroupBy(x => x)
                                         .Where(g => g.Count() > 1)
-                                        .Select(y => new { Element = y.Key, Counter = y.Count() })
-                                        .ToList();
+                                        .Select(y => new { Element = y.Key, Counter = y.Count() });
 
-            if (doublons == null || !doublons.Any()) return result;
-            foreach (var doublon in doublons)
+            foreach (var duplicate in duplicates)
             {
-                var error = new LexerInitializationError(ErrorLevel.FATAL,
-                    $"char or string lexeme dilimiter {doublon.Element} is used {doublon.Counter} times. This will results in lexing conflicts");
-                result.Errors.Add(error);
+                result.AddError(new LexerInitializationError(ErrorLevel.FATAL,
+                    $"char or string lexeme dilimiter {duplicate.Element} is used {duplicate.Counter} times. This will results in lexing conflicts"));
             }
 
             return result;
@@ -374,38 +315,53 @@ namespace sly.lexer
 
         private static Dictionary<IN, List<CommentAttribute>> GetCommentsAttribute<IN>(BuildResult<ILexer<IN>> result) where IN : struct
         {
-            var values = Enum.GetValues(typeof(IN));
-
             var attributes = new Dictionary<IN, List<CommentAttribute>>();
-    
-            var fields = typeof(IN).GetFields();
+
+            var values = Enum.GetValues(typeof(IN));
             foreach (Enum value in values)
             {
                 var tokenID = (IN) (object) value;
                 var enumAttributes = value.GetAttributesOfType<CommentAttribute>();
-                if (enumAttributes != null && enumAttributes.Any()) attributes[tokenID] = enumAttributes;
+                if (enumAttributes != null && enumAttributes.Any()) attributes[tokenID] = enumAttributes.ToList();
             }
 
-            var commentCount = attributes.Values.ToList().Select(l => l?.Count(attr => attr.GetType() == typeof(CommentAttribute)) ?? 0).ToList().Sum();
-            var multiLineCommentCount = attributes.Values.ToList().Select(l => l?.Count(attr => attr.GetType() == typeof(MultiLineCommentAttribute)) ?? 0).ToList().Sum();
-            var singleLineCommentCount = attributes.Values.ToList().Select(l => l?.Count(attr => attr.GetType() == typeof(SingleLineCommentAttribute)) ?? 0).ToList().Sum();
+            var commentCount = attributes.Values.Select(l => l?.Count(attr => attr.GetType() == typeof(CommentAttribute)) ?? 0).Sum();
+            var multiLineCommentCount = attributes.Values.Select(l => l?.Count(attr => attr.GetType() == typeof(MultiLineCommentAttribute)) ?? 0).Sum();
+            var singleLineCommentCount = attributes.Values.Select(l => l?.Count(attr => attr.GetType() == typeof(SingleLineCommentAttribute)) ?? 0).Sum();
 
-            if (commentCount > 1) result.AddError(new LexerInitializationError(ErrorLevel.FATAL, "too many comment lexem"));
+            if (commentCount > 1)
+            {
+                result.AddError(new LexerInitializationError(ErrorLevel.FATAL, "too many comment lexem"));
+            }
 
-            if (multiLineCommentCount > 1) result.AddError(new LexerInitializationError(ErrorLevel.FATAL, "too many multi-line comment lexem"));
-            if (singleLineCommentCount > 1) result.AddError(new LexerInitializationError(ErrorLevel.FATAL, "too many single-line comment lexem"));
+            if (multiLineCommentCount > 1)
+            {
+                result.AddError(new LexerInitializationError(ErrorLevel.FATAL, "too many multi-line comment lexem"));
+            }
 
-            if (commentCount > 0 && (multiLineCommentCount > 0 || singleLineCommentCount > 0)) result.AddError(new LexerInitializationError(ErrorLevel.FATAL, "comment lexem can't be used together with single-line or multi-line comment lexems"));
+            if (singleLineCommentCount > 1)
+            {
+                result.AddError(new LexerInitializationError(ErrorLevel.FATAL, "too many single-line comment lexem"));
+            }
+
+            if (commentCount > 0 && (multiLineCommentCount > 0 || singleLineCommentCount > 0))
+            {
+                result.AddError(new LexerInitializationError(ErrorLevel.FATAL, "comment lexem can't be used together with single-line or multi-line comment lexems"));
+            }
 
             return attributes;
         }
 
-        private static void AddExtensions<IN>(Dictionary<IN, LexemeAttribute> Extensions,
+        private static void AddExtensions<IN>(Dictionary<IN, LexemeAttribute> extensions,
             BuildExtension<IN> extensionBuilder, GenericLexer<IN> lexer) where IN : struct
         {
             if (extensionBuilder != null)
-                foreach (var attr in Extensions)
+            {
+                foreach (var attr in extensions)
+                {
                     extensionBuilder(attr.Key, attr.Value, lexer);
+                }
+            }
         }
     }
 }

--- a/sly/lexer/LexerBuilder.cs
+++ b/sly/lexer/LexerBuilder.cs
@@ -149,6 +149,7 @@ namespace sly.lexer
                 config.IgnoreWS = lexerAttribute.IgnoreWS;
                 config.IgnoreEOL = lexerAttribute.IgnoreEOL;
                 config.WhiteSpace = lexerAttribute.WhiteSpace;
+                config.KeyWordIgnoreCase = lexerAttribute.KeyWordIgnoreCase;
             }
 
             var statics = new List<GenericToken>();

--- a/sly/lexer/LexerBuilder.cs
+++ b/sly/lexer/LexerBuilder.cs
@@ -159,14 +159,43 @@ namespace sly.lexer
                 if (lexeme.IsIdentifier)
                 {
                     config.IdType = lexeme.IdentifierType;
+                    if (lexeme.IdentifierType == IdentifierType.Custom)
+                    {
+                        config.IdentifierStartPattern = ParseIdentifierPattern(lexeme.IdentifierStartPattern);
+                        config.IdentifierRestPattern = ParseIdentifierPattern(lexeme.IdentifierRestPattern);
+                    }
                 }
             }
 
             return (config, statics.Distinct().ToArray());
         }
+        
+        private static IEnumerable<char[]> ParseIdentifierPattern(string pattern)
+        {
+            var index = 0;
+            while (index < pattern.Length)
+            {
+                if (index <= pattern.Length - 3 && pattern[index + 1] == '-')
+                {
+                    if (pattern[index] < pattern[index + 2])
+                    {
+                        yield return new[] { pattern[index], pattern[index + 2] };
+                    }
+                    else
+                    {
+                        yield return new[] { pattern[index + 2], pattern[index] };
+                    }
+                    index += 3;
+                }
+                else
+                {
+                    yield return new[] { pattern[index++] };
+                }
+            }
+        }
 
         private static BuildResult<ILexer<IN>> BuildGenericLexer<IN>(Dictionary<IN, List<LexemeAttribute>> attributes,
-            BuildExtension<IN> extensionBuilder, BuildResult<ILexer<IN>> result) where IN : struct
+                                                                     BuildExtension<IN> extensionBuilder, BuildResult<ILexer<IN>> result) where IN : struct
         {
             result = CheckStringAndCharTokens(attributes, result);
             var (config, tokens) = GetConfigAndGenericTokens(attributes);

--- a/sly/lexer/fsm/FSMLexerBuilder.cs
+++ b/sly/lexer/fsm/FSMLexerBuilder.cs
@@ -71,22 +71,34 @@ namespace sly.lexer.fsm
 
         #region special chars
 
-        public FSMLexerBuilder<N> IgnoreWS()
+        public FSMLexerBuilder<N> IgnoreWS(bool ignore = true)
         {
-            Fsm.IgnoreWhiteSpace = true;
+            Fsm.IgnoreWhiteSpace = ignore;
             return this;
         }
 
-        public FSMLexerBuilder<N> IgnoreEOL()
+        public FSMLexerBuilder<N> IgnoreEOL(bool ignore = true)
         {
-            Fsm.IgnoreEOL = true;
+            Fsm.IgnoreEOL = ignore;
             return this;
         }
 
-
-        public FSMLexerBuilder<N> WhiteSpace(char spacechar)
+        public FSMLexerBuilder<N> WhiteSpace(char spaceChar)
         {
-            Fsm.WhiteSpaces.Add(spacechar);
+            Fsm.WhiteSpaces.Add(spaceChar);
+            return this;
+        }
+
+        public FSMLexerBuilder<N> WhiteSpace(char[] spaceChars)
+        {
+            if (spaceChars != null)
+            {
+                foreach (var spaceChar in spaceChars)
+                {
+                    Fsm.WhiteSpaces.Add(spaceChar);
+                }
+            }
+
             return this;
         }
 

--- a/sly/lexer/fsm/FSMMatch.cs
+++ b/sly/lexer/fsm/FSMMatch.cs
@@ -5,30 +5,25 @@ namespace sly.lexer.fsm
 {
     public class FSMMatch<N>
     {
-        public char StringDelimiter = '"';
+        public Dictionary<string, object> Properties { get; }
 
-        
-        public Dictionary<string, object> Properties { get; set; }
+        public bool IsSuccess { get; }
 
-        public bool IsSuccess { get; set; }
-        
-        public bool IsEOS { get; set; }
+        public bool IsEOS { get; }
 
-        public Token<N> Result { get; set; }
-        
-        public int NodeId { get; set; }
+        public Token<N> Result { get; }
+
+        public int NodeId { get; }
+
         public FSMMatch(bool success)
         {
             IsSuccess = success;
-            if (!IsSuccess)
-            {
-                IsEOS = true;
-            }
+            IsEOS = !success;
         }
-        
-        public FSMMatch(bool success, N result, string value, TokenPosition position,int nodeId) : this(success,result,new ReadOnlyMemory<char>(value.ToCharArray()),position,nodeId )
-        {
-        }
+
+        public FSMMatch(bool success, N result, string value, TokenPosition position, int nodeId)
+            : this(success, result, new ReadOnlyMemory<char>(value.ToCharArray()), position, nodeId)
+        { }
 
         public FSMMatch(bool success, N result, ReadOnlyMemory<char> value, TokenPosition position, int nodeId)
         {
@@ -38,9 +33,5 @@ namespace sly.lexer.fsm
             IsEOS = false;
             Result = new Token<N>(result, value, position);
         }
-        
-        
-
-        
     }
 }

--- a/sly/sly.csproj
+++ b/sly/sly.csproj
@@ -24,7 +24,7 @@
      <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request enables configuration of the lexer:
- The Lexer `enum` can have an attribute `[Lexer]`. This attribute has properties that control:
  * _IgnoreWS_: Should the lexer ignore whitespace? Default is true.
  * _IgnoreEOL_: Should the lexer ignore end-of-line characters? Default is true.
  * _WhiteSpace_: Set which characters are regarded as whitespace. Default is space and tab.
  * _KeyWordIgnoreCase_ : Should the lexer ignore case for keywords? Default is false.
- The `IdentifierType` has a new value `Custom`, and the `Lexeme` attribute has two new properties `IdentifierStartPattern` and `IdentifierRestPattern`. This allows the user to configure the FSM identifier recognition. The pattern is a string of characters. Ranges can also be used. Example:  start = `"_a-zA-Z"` and rest = `"-_a-zA-Z0-9"` corresponds to the `AlphaNumericDash` identifier type.

The Lexer also correctly handles empty input and input consisting of only ignored characters.