### PR TITLE
Allow subclasses of ParserBuilder to override BuildLexer()

### DIFF
--- a/sly/parser/generator/ParserBuilder.cs
+++ b/sly/parser/generator/ParserBuilder.cs
@@ -118,7 +118,7 @@ namespace sly.parser.generator
         }
 
 
-        protected BuildResult<ILexer<IN>> BuildLexer()
+        protected virtual BuildResult<ILexer<IN>> BuildLexer()
         {
             var lexer = LexerBuilder.BuildLexer(new BuildResult<ILexer<IN>>());
             return lexer;


### PR DESCRIPTION
 This will enable us to configure a parser with a custom lexer.