### PR TITLE
Fixed error in SyntaxTreeGraphVizTest()

### DIFF
--- a/ParserTests/GraphVizTests.cs
+++ b/ParserTests/GraphVizTests.cs
@@ -68,7 +68,7 @@ namespace ParserTests
         {
             var StartingRule = $"{typeof(SimpleExpressionParser).Name}_expressions";
             var parserInstance = new SimpleExpressionParser();
-            var builder = new ParserBuilder<ExpressionToken, int>();
+            var builder = new ParserBuilder<ExpressionToken, double>();
             var  Parser = builder.BuildParser(parserInstance, ParserType.LL_RECURSIVE_DESCENT, StartingRule);
             var result = Parser.Result.Parse("1+1");
 


### PR DESCRIPTION
OUT type in the Parser was int, causing a boxed double in
SimpleExpressionParser to be cast to int, which caused an
InvalidCastException. Fixed by using OUT type double.