### PR TITLE
Optimized Expression Rules for #165

### DIFF
--- a/sly/parser/syntax/grammar/Rule.cs
+++ b/sly/parser/syntax/grammar/Rule.cs
@@ -33,11 +33,12 @@ namespace sly.parser.syntax.grammar
         {
             get
             {
-                var k = Clauses
-                    .Select(c => c.ToString())
-                    .Aggregate((c1, c2) => c1.ToString() + "_" + c2.ToString());
-                if (Clauses.Count == 1) k += "_";
-                return k;
+                var key = string.Join("_", Clauses.Select(c => c.ToString()));
+                
+                if (Clauses.Count == 1) 
+                    key += "_";
+
+                return IsExpressionRule ? key.Replace(" | ", "_") : key;
             }
         }
 


### PR DESCRIPTION
The purpose of this change is to drastically reduce the number of expression rules being created by utilizing the choice clause.

Instead of: 
left_clause op_a right_clause
left_clause op_b right_clause
left_clause op_c right_clause

We simply have:
left_clause [op_a | op_b | op_c] right_clause

Given a test string `a = close[3] / (2 + 2)` with 16 different generic expressions and about 10 possible leading tokens, my parsing time when from 32465ms down to 144ms!!!

CP3088