### PR TITLE
Compiled Regex for a performance boost of regex lexer

### DIFF
--- a/sly/lexer/TokenDefinition.cs
+++ b/sly/lexer/TokenDefinition.cs
@@ -23,7 +23,7 @@ namespace sly.lexer
         public TokenDefinition(T token, string regex, bool isIgnored = false, bool isEndOfLine = false)
         {
             TokenID = token;
-            Regex = new Regex(regex);
+            Regex = new Regex(regex, RegexOptions.Compiled);
             IsIgnored = isIgnored;
             IsEndOfLine = isEndOfLine;
         }


### PR DESCRIPTION
I've always known (from theory) that compiled `Regex` perform better at runtime at the expense of a bit more time during construction. Since (from what I can see) you are reusing Regex instances, then perhaps compiling them will help the performance. 

I didn't test it and wonder if you had a benchmark to compare to 😄 