### PR TITLE
Added possibility of name for operation

### DIFF
--- a/sly/parser/generator/OperationAttribute.cs
+++ b/sly/parser/generator/OperationAttribute.cs
@@ -26,10 +26,11 @@ namespace sly.parser.generator
         ///     token as an int as attribute can not be generics.
         /// </summary>
         /// <param name="intToken">token enum as int value</param>
-        /// <param name="arity">operator arity</param>
+        /// <param name="affix">operator affix (<see cref="Affix" />)</param>
         /// <param name="assoc">operator aosociativity (<see cref="Associativity" />) </param>
         /// <param name="precedence">precedence level: the greater, the higher</param>
-        public OperationAttribute(int intToken, Affix affix, Associativity assoc, int precedence)
+        /// <param name="name">operation name</param>
+        public OperationAttribute(int intToken, Affix affix, Associativity assoc, int precedence, string name = "Default")
         {
             IntToken = intToken;
             IsIntToken = true;
@@ -37,9 +38,10 @@ namespace sly.parser.generator
             Affix = affix;
             Assoc = assoc;
             Precedence = precedence;
+            Name = name;
         }
-        
-        public OperationAttribute(string stringToken, Affix affix, Associativity assoc, int precedence)
+
+        public OperationAttribute(string stringToken, Affix affix, Associativity assoc, int precedence, string name = "Default")
         {
             StringToken = stringToken;
             IsStringToken = true;
@@ -47,15 +49,16 @@ namespace sly.parser.generator
             Affix = affix;
             Assoc = assoc;
             Precedence = precedence;
+            Name = name;
         }
 
         public bool IsIntToken { get; set; }
-        
+
         public bool IsStringToken { get; set; }
-        
-        
+
+
         public int IntToken { get; set; }
-        
+
         public string StringToken { get; set; }
 
         public Affix Affix { get; set; }
@@ -63,5 +66,7 @@ namespace sly.parser.generator
         public Associativity Assoc { get; set; }
 
         public int Precedence { get; set; }
+
+        public string Name { get; set; }
     }
 }


### PR DESCRIPTION
Added a way to name the operations, so you can create an operation with relational operators to use in a condition and the parser doesn't get confused with some operation that uses mathematical operators. By not using a name, the functionality remains the same. (parsersClass_expressions)

For example, look at these rules:

[Production("ifstatement: IF LPAREN parserClass_expressions_relational RPAREN LBRACKET statements? RBRACKET elsestatement?")]


AND

[Operation((int)Tokens.LESSER, Affix.InFix, Associativity.Right, 50, "relational")]
[Operation((int)Tokens.LESSEROREQUAL, Affix.InFix, Associativity.Right, 50, "relational")]
[Operation((int)Tokens.GREATER, Affix.InFix, Associativity.Right, 50, "relational")]
[Operation((int)Tokens.GREATEROREQUAL, Affix.InFix, Associativity.Right, 50, "relational")]
[Operation((int)Tokens.EQUALS, Affix.InFix, Associativity.Right, 50, "relational")]
[Operation((int)Tokens.DIFFERENT, Affix.InFix, Associativity.Right, 50, "relational")]


AND


[Operation((int)Tokens.PLUS, Affix.InFix, Associativity.Right, 10, "matematical")]
[Operation((int)Tokens.MINUS, Affix.InFix, Associativity.Right, 10, "matematical")]