### PR TITLE
optim : remove useless call to SyntaxTreeCleaner.SetAssociativity whe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# C# lex and yacc #
+# C# lex and yacc #      
 
 
 ![Test status](http://teststatusbadge.azurewebsites.net/api/status/mmaitre314/securestringcodegen)

--- a/sly/parser/generator/ExpressionRulesGenerator.cs
+++ b/sly/parser/generator/ExpressionRulesGenerator.cs
@@ -94,6 +94,7 @@ namespace sly.parser.generator
                 }
             });
 
+            
             if (operationsByPrecedence.Count > 0)
             {
                 var operandNonTerminal = GetOperandNonTerminal(parserClass,configuration, result);
@@ -104,6 +105,7 @@ namespace sly.parser.generator
                         parserClass.Name);
             }
 
+            configuration.UsesOperations = operationsByPrecedence.Any(); 
             result.Result = configuration;
             return result;
         }

--- a/sly/parser/generator/ParserConfiguration.cs
+++ b/sly/parser/generator/ParserConfiguration.cs
@@ -9,6 +9,7 @@ namespace sly.parser.generator
         public string StartingRule { get; set; }
         public Dictionary<string, NonTerminal<IN>> NonTerminals { get; set; }
 
+        public bool UsesOperations { get; set; }
 
         public void AddNonTerminalIfNotExists(NonTerminal<IN> nonTerminal)
         {

--- a/sly/parser/parser/Parser.cs
+++ b/sly/parser/parser/Parser.cs
@@ -102,6 +102,7 @@ namespace sly.parser
 
             var cleaner = new SyntaxTreeCleaner<IN>();
             var syntaxResult = SyntaxParser.Parse(tokens, startingNonTerminal);
+            syntaxResult.UsesOperations = Configuration.UsesOperations;
             syntaxResult = cleaner.CleanSyntaxTree(syntaxResult);
             if (!syntaxResult.IsError && syntaxResult.Root != null)
             {

--- a/sly/parser/parser/SyntaxParseResult.cs
+++ b/sly/parser/parser/SyntaxParseResult.cs
@@ -29,6 +29,6 @@ namespace sly.parser
         }
 
         public bool HasByPassNodes { get; set; } = false;
-
+        public bool UsesOperations { get; set; }
     }
 }

--- a/sly/parser/parser/SyntaxTreeCleaner.cs
+++ b/sly/parser/parser/SyntaxTreeCleaner.cs
@@ -16,28 +16,11 @@ namespace sly.parser.parser
                 }
                     
                 
-                if (NeedAssociativityProcessing(tree)) tree = SetAssociativity(tree);
+                if (result.UsesOperations) tree = SetAssociativity(tree);
                 result.Root = tree;
             }
 
             return result;
-        }
-
-        private bool NeedAssociativityProcessing(ISyntaxNode<IN> tree)
-        {
-            var need = false;
-            if (tree is ManySyntaxNode<IN> many)
-                foreach (var child in many.Children)
-                {
-                    need = need || NeedAssociativityProcessing(child);
-                    if (need) break;
-                }
-            else if (tree is SyntaxLeaf<IN> leaf)
-                need = false;
-            else if (tree is SyntaxNode<IN> node) need = true;
-                
-
-            return need;
         }
 
         private ISyntaxNode<IN> RemoveByPassNodes(ISyntaxNode<IN> tree)


### PR DESCRIPTION
…n no operation attributes were used