### PR TITLE
Experiment/string delim escape opt in

### DIFF
--- a/src/benchCurrent/GenericLexerBench.cs
+++ b/src/benchCurrent/GenericLexerBench.cs
@@ -25,7 +25,7 @@ namespace benchCurrent
             }
         }
 
-        private ILexer<JsonTokenGeneric> BenchedLexer;
+        private ILexer<JsonTokenGenericEscaped> BenchedLexer;
 
         private string content = "";
 
@@ -34,7 +34,7 @@ namespace benchCurrent
         {
             content = File.ReadAllText("test.json");
 
-            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<JsonTokenGeneric>>());
+            var lexerRes = LexerBuilder.BuildLexer(new BuildResult<ILexer<JsonTokenGenericEscaped>>());
             if (lexerRes != null)
             {
                 BenchedLexer = lexerRes.Result;

--- a/src/benchCurrent/JsonParserBench.cs
+++ b/src/benchCurrent/JsonParserBench.cs
@@ -27,7 +27,7 @@ namespace benchCurrent
             }
         }
 
-        private Parser<JsonTokenGeneric,JSon> BenchedParser;
+        private Parser<JsonTokenGenericNotEscaped,JSon> BenchedParser;
 
         private string content = "";
 
@@ -38,7 +38,7 @@ namespace benchCurrent
             content = File.ReadAllText("test.json");
             Console.WriteLine("json read.");
             var jsonParser = new EbnfJsonGenericParser();
-            var builder = new ParserBuilder<JsonTokenGeneric, JSon>();
+            var builder = new ParserBuilder<JsonTokenGenericNotEscaped, JSon>();
             
             var result = builder.BuildParser(jsonParser, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
             Console.WriteLine("parser built.");

--- a/src/benchCurrent/JsonStringEscapingBench.cs
+++ b/src/benchCurrent/JsonStringEscapingBench.cs
@@ -1,0 +1,6 @@
+namespace benchCurrent;
+
+public class JsonStringEscapingBench
+{
+    
+}

--- a/src/benchCurrent/JsonStringEscapingBench.cs
+++ b/src/benchCurrent/JsonStringEscapingBench.cs
@@ -1,6 +1,105 @@
+using System;
+using System.IO;
+using bench.json;
+using bench.json.model;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.CsProj;
+using simpleExpressionParser;
+using sly.parser;
+using sly.parser.generator;
+
 namespace benchCurrent;
 
+
+[MemoryDiagnoser]
+    
+[Config(typeof(JsonStringEscapingBench.Config))]
 public class JsonStringEscapingBench
 {
+    private class Config : ManualConfig
+    {
+        public Config()
+        {
+            var baseJob = Job.MediumRun.With(CsProjCoreToolchain.NetCoreApp70);
+        }
+    }
+    
+    private Parser<JsonTokenGeneric, JSon> escapedJsonParser;
+    private Parser<JsonTokenGenericStringNotEscaped, JSon> unescapedJsonParser;
+    
+    private string content = "";
+    
+    [GlobalSetup]
+    public void Setup()
+    {
+        Console.WriteLine(("SETUP"));
+        content = File.ReadAllText("test.json");
+        Console.WriteLine("json read.");
+        var jsonParser = new EbnfJsonGenericParser();
+        var builder = new ParserBuilder<JsonTokenGeneric, JSon>();
+            
+        var result = builder.BuildParser(jsonParser, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
+        Console.WriteLine("parser built.");
+        if (result.IsError)
+        {
+            Console.WriteLine("ERROR");
+            result.Errors.ForEach(Console.WriteLine);
+        }
+        else
+        {
+            Console.WriteLine("parser ok");
+            escapedJsonParser = result.Result;
+        }
+            
+        var notJsonParser = new EbnfJsonGenericParserStringNotEscaped();
+        var builderNot = new ParserBuilder<JsonTokenGenericStringNotEscaped, JSon>();
+            
+        var resultNot = builderNot.BuildParser(notJsonParser, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
+        Console.WriteLine("parser built.");
+        if (resultNot.IsError)
+        {
+            Console.WriteLine("ERROR");
+            resultNot.Errors.ForEach(Console.WriteLine);
+        }
+        else
+        {
+            Console.WriteLine("parser ok");
+            unescapedJsonParser = resultNot.Result;
+        }
+    }
+    
+    [Benchmark]
+        
+    public void TestEscapedJson()
+    {
+            
+            
+        if (escapedJsonParser == null)
+        {
+            Console.WriteLine("parser is null");
+        }
+        else
+        {
+            var ignored = escapedJsonParser.Parse(content);    
+        }
+    }
+    
+    [Benchmark]
+        
+    public void TestUnescapedJson()
+    {
+            
+            
+        if (unescapedJsonParser == null)
+        {
+            Console.WriteLine("parser is null");
+        }
+        else
+        {
+            var ignored = unescapedJsonParser.Parse(content);    
+        }
+    }
     
 }

--- a/src/benchCurrent/JsonStringEscapingBench.cs
+++ b/src/benchCurrent/JsonStringEscapingBench.cs
@@ -26,8 +26,8 @@ public class JsonStringEscapingBench
         }
     }
     
-    private Parser<JsonTokenGeneric, JSon> escapedJsonParser;
-    private Parser<JsonTokenGenericStringNotEscaped, JSon> unescapedJsonParser;
+    private Parser<JsonTokenGenericNotEscaped, JSon> notEscapedJsonParser;
+    private Parser<JsonTokenGenericEscaped, JSon> escapedJsonParser;
     
     private string content = "";
     
@@ -38,7 +38,7 @@ public class JsonStringEscapingBench
         content = File.ReadAllText("test.json");
         Console.WriteLine("json read.");
         var jsonParser = new EbnfJsonGenericParser();
-        var builder = new ParserBuilder<JsonTokenGeneric, JSon>();
+        var builder = new ParserBuilder<JsonTokenGenericNotEscaped, JSon>();
             
         var result = builder.BuildParser(jsonParser, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
         Console.WriteLine("parser built.");
@@ -50,11 +50,11 @@ public class JsonStringEscapingBench
         else
         {
             Console.WriteLine("parser ok");
-            escapedJsonParser = result.Result;
+            notEscapedJsonParser = result.Result;
         }
             
         var notJsonParser = new EbnfJsonGenericParserStringNotEscaped();
-        var builderNot = new ParserBuilder<JsonTokenGenericStringNotEscaped, JSon>();
+        var builderNot = new ParserBuilder<JsonTokenGenericEscaped, JSon>();
             
         var resultNot = builderNot.BuildParser(notJsonParser, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
         Console.WriteLine("parser built.");
@@ -66,7 +66,23 @@ public class JsonStringEscapingBench
         else
         {
             Console.WriteLine("parser ok");
-            unescapedJsonParser = resultNot.Result;
+            escapedJsonParser = resultNot.Result;
+        }
+    }
+    
+    [Benchmark]
+        
+    public void TestNotEscapedJson()
+    {
+            
+            
+        if (notEscapedJsonParser == null)
+        {
+            Console.WriteLine("parser is null");
+        }
+        else
+        {
+            var ignored = notEscapedJsonParser.Parse(content);    
         }
     }
     
@@ -83,22 +99,6 @@ public class JsonStringEscapingBench
         else
         {
             var ignored = escapedJsonParser.Parse(content);    
-        }
-    }
-    
-    [Benchmark]
-        
-    public void TestUnescapedJson()
-    {
-            
-            
-        if (unescapedJsonParser == null)
-        {
-            Console.WriteLine("parser is null");
-        }
-        else
-        {
-            var ignored = unescapedJsonParser.Parse(content);    
         }
     }
     

--- a/src/benchCurrent/Program.cs
+++ b/src/benchCurrent/Program.cs
@@ -6,7 +6,7 @@ namespace benchCurrent
     static class Program
     {
 
-        private static void BenchJson() {
+        private static void Bench() {
            
             // var summary = BenchmarkRunner.Run<JsonParserBench>();
             //
@@ -14,7 +14,8 @@ namespace benchCurrent
             
             // var summary3 = BenchmarkRunner.Run<WhileBench>();
 
-            var summary4 = BenchmarkRunner.Run<SimpleExpressionBench>();
+            //var summary4 = BenchmarkRunner.Run<SimpleExpressionBench>();
+            var summary5 = BenchmarkRunner.Run<JsonStringEscapingBench>();
 
         }
         static void Main(string[] args)
@@ -22,7 +23,7 @@ namespace benchCurrent
             try
             {
                 Console.WriteLine("Hello World!");
-                BenchJson();
+                Bench();
             }
             catch (Exception e)
             {

--- a/src/benchCurrent/json/EbnfJsonGenericParser.cs
+++ b/src/benchCurrent/json/EbnfJsonGenericParser.cs
@@ -153,4 +153,154 @@ namespace bench.json
 
         #endregion
     }
+    
+     [BroadenTokenWindow]
+    [ParserRoot("root")]
+    public class EbnfJsonGenericParserStringNotEscaped
+    {
+        #region root
+
+        [Production("root : value")]
+        public JSon Root(JSon value)
+        {
+            return value;
+        }
+
+        #endregion
+
+        #region VALUE
+
+        [Production("value : STRING")]
+        public JSon StringValue(Token<JsonTokenGenericStringNotEscaped> stringToken)
+        {
+            return new JValue(stringToken.StringWithoutQuotes);
+        }
+
+        [Production("value : INT")]
+        public JSon IntValue(Token<JsonTokenGenericStringNotEscaped> intToken)
+        {
+            return new JValue(intToken.IntValue);
+        }
+
+        [Production("value : DOUBLE")]
+        public JSon DoubleValue(Token<JsonTokenGenericStringNotEscaped> doubleToken)
+        {
+            double dbl;
+            try
+            {
+                var doubleParts = doubleToken.Value.Split('.');
+                dbl = double.Parse(doubleParts[0]);
+                if (doubleParts.Length > 1)
+                {
+                    var decimalPart = double.Parse(doubleParts[1]);
+                    for (var i = 0; i < doubleParts[1].Length; i++) decimalPart = decimalPart / 10.0;
+                    dbl += decimalPart;
+                }
+            }
+            catch (Exception)
+            {
+                dbl = double.MinValue;
+            }
+
+            return new JValue(dbl);
+        }
+
+        [Production("value : BOOLEAN")]
+        public JSon BooleanValue(Token<JsonTokenGenericStringNotEscaped> boolToken)
+        {
+            return new JValue(bool.Parse(boolToken.Value));
+        }
+
+        [Production("value : NULL[d]")]
+        public JSon NullValue()
+        {
+            return new JNull();
+        }
+
+        [Production("value : object")]
+        public JSon ObjectValue(JSon value)
+        {
+            return value;
+        }
+
+        [Production("value: list")]
+        public JSon ListValue(JList list)
+        {
+            return list;
+        }
+
+        #endregion
+
+        #region OBJECT
+
+        [Production("object: ACCG[d] ACCD[d]")]
+        public JSon EmptyObjectValue()
+        {
+            return new JObject();
+        }
+
+        [Production("object: ACCG[d] members ACCD[d]")]
+        public JSon AttributesObjectValue(JObject members)
+        {
+            return members;
+        }
+
+        #endregion
+
+        #region LIST
+
+        [Production("list: CROG[d] CROD[d]")]
+        public JSon EmptyList()
+        {
+            return new JList();
+        }
+
+        [Production("list: CROG[d] listElements CROD[d]")]
+        public JSon List(JList elements)
+        {
+            return elements;
+        }
+
+
+        [Production("listElements: value additionalValue*")]
+        public JSon listElements(JSon head, List<JSon> tail)
+        {
+            var values = new JList(head);
+            values.AddRange(tail);
+            return values;
+        }
+
+        [Production("additionalValue: COMMA value")]
+        public JSon ListElementsOne(Token<JsonTokenGenericStringNotEscaped> discardedComma, JSon value)
+        {
+            return value;
+        }
+
+        #endregion
+
+        #region PROPERTIES
+
+        [Production("members: property additionalProperty*")]
+        public JSon Members(JObject head, List<JSon> tail)
+        {
+            var value = new JObject();
+            value.Merge(head);
+            foreach (var p in tail) value.Merge((JObject) p);
+            return value;
+        }
+
+        [Production("additionalProperty : COMMA property")]
+        public JSon property(Token<JsonTokenGenericStringNotEscaped> comma, JObject property)
+        {
+            return property;
+        }
+
+        [Production("property: STRING COLON[d] value")]
+        public JSon property(Token<JsonTokenGenericStringNotEscaped> key, JSon value)
+        {
+            return new JObject(key.StringWithoutQuotes, value);
+        }
+
+        #endregion
+    }
 }

--- a/src/benchCurrent/json/EbnfJsonGenericParser.cs
+++ b/src/benchCurrent/json/EbnfJsonGenericParser.cs
@@ -21,19 +21,19 @@ namespace bench.json
         #region VALUE
 
         [Production("value : STRING")]
-        public JSon StringValue(Token<JsonTokenGeneric> stringToken)
+        public JSon StringValue(Token<JsonTokenGenericNotEscaped> stringToken)
         {
             return new JValue(stringToken.StringWithoutQuotes);
         }
 
         [Production("value : INT")]
-        public JSon IntValue(Token<JsonTokenGeneric> intToken)
+        public JSon IntValue(Token<JsonTokenGenericNotEscaped> intToken)
         {
             return new JValue(intToken.IntValue);
         }
 
         [Production("value : DOUBLE")]
-        public JSon DoubleValue(Token<JsonTokenGeneric> doubleToken)
+        public JSon DoubleValue(Token<JsonTokenGenericNotEscaped> doubleToken)
         {
             double dbl;
             try
@@ -56,7 +56,7 @@ namespace bench.json
         }
 
         [Production("value : BOOLEAN")]
-        public JSon BooleanValue(Token<JsonTokenGeneric> boolToken)
+        public JSon BooleanValue(Token<JsonTokenGenericNotEscaped> boolToken)
         {
             return new JValue(bool.Parse(boolToken.Value));
         }
@@ -146,7 +146,7 @@ namespace bench.json
         }
 
         [Production("property: STRING COLON[d] value")]
-        public JSon property(Token<JsonTokenGeneric> key, JSon value)
+        public JSon property(Token<JsonTokenGenericNotEscaped> key, JSon value)
         {
             return new JObject(key.StringWithoutQuotes, value);
         }
@@ -171,19 +171,19 @@ namespace bench.json
         #region VALUE
 
         [Production("value : STRING")]
-        public JSon StringValue(Token<JsonTokenGenericStringNotEscaped> stringToken)
+        public JSon StringValue(Token<JsonTokenGenericEscaped> stringToken)
         {
             return new JValue(stringToken.StringWithoutQuotes);
         }
 
         [Production("value : INT")]
-        public JSon IntValue(Token<JsonTokenGenericStringNotEscaped> intToken)
+        public JSon IntValue(Token<JsonTokenGenericEscaped> intToken)
         {
             return new JValue(intToken.IntValue);
         }
 
         [Production("value : DOUBLE")]
-        public JSon DoubleValue(Token<JsonTokenGenericStringNotEscaped> doubleToken)
+        public JSon DoubleValue(Token<JsonTokenGenericEscaped> doubleToken)
         {
             double dbl;
             try
@@ -206,7 +206,7 @@ namespace bench.json
         }
 
         [Production("value : BOOLEAN")]
-        public JSon BooleanValue(Token<JsonTokenGenericStringNotEscaped> boolToken)
+        public JSon BooleanValue(Token<JsonTokenGenericEscaped> boolToken)
         {
             return new JValue(bool.Parse(boolToken.Value));
         }
@@ -271,7 +271,7 @@ namespace bench.json
         }
 
         [Production("additionalValue: COMMA value")]
-        public JSon ListElementsOne(Token<JsonTokenGenericStringNotEscaped> discardedComma, JSon value)
+        public JSon ListElementsOne(Token<JsonTokenGenericEscaped> discardedComma, JSon value)
         {
             return value;
         }
@@ -290,13 +290,13 @@ namespace bench.json
         }
 
         [Production("additionalProperty : COMMA property")]
-        public JSon property(Token<JsonTokenGenericStringNotEscaped> comma, JObject property)
+        public JSon property(Token<JsonTokenGenericEscaped> comma, JObject property)
         {
             return property;
         }
 
         [Production("property: STRING COLON[d] value")]
-        public JSon property(Token<JsonTokenGenericStringNotEscaped> key, JSon value)
+        public JSon property(Token<JsonTokenGenericEscaped> key, JSon value)
         {
             return new JObject(key.StringWithoutQuotes, value);
         }

--- a/src/benchCurrent/json/JsonTokenGeneric.cs
+++ b/src/benchCurrent/json/JsonTokenGeneric.cs
@@ -18,4 +18,25 @@ namespace bench.json
         [Lexeme(GenericToken.SugarToken, ":")] COLON = 10,
         [Lexeme(GenericToken.KeyWord, "null")] NULL = 14
     }
+    
+    public enum JsonTokenGenericStringNotEscaped
+    {
+        [String(doEscape:true, channel:0)] STRING = 1,
+        [Double(channel:0)] DOUBLE = 2,
+        [Lexeme(GenericToken.Int,channel:0)] INT = 3,
+
+        [Keyword("true", channel:0)]
+        [Keyword("false", channel:0)]
+        BOOLEAN = 4,
+        [Keyword( "null",channel:0)] NULL = 14,
+        
+        
+        [Sugar("{",channel:0)] ACCG = 5,
+        [Sugar( "}",channel:0)] ACCD = 6,
+        [Sugar( "[",channel:0)] CROG = 7,
+        [Sugar( "]",channel:0)] CROD = 8,
+        [Sugar( ",",channel:0)] COMMA = 9,
+        [Sugar( ":",channel:0)] COLON = 10,
+        
+    }
 }

--- a/src/benchCurrent/json/JsonTokenGeneric.cs
+++ b/src/benchCurrent/json/JsonTokenGeneric.cs
@@ -4,7 +4,7 @@ namespace bench.json
 {
     public enum JsonTokenGeneric
     {
-        [Lexeme(GenericToken.String)] STRING = 1,
+        [String(doEscape:false, channel:0)] STRING = 1,
         [Lexeme(GenericToken.Double)] DOUBLE = 2,
         [Lexeme(GenericToken.Int)] INT = 3,
 

--- a/src/benchCurrent/json/JsonTokenGenericNotEscaped.cs
+++ b/src/benchCurrent/json/JsonTokenGenericNotEscaped.cs
@@ -2,7 +2,7 @@
 
 namespace bench.json
 {
-    public enum JsonTokenGeneric
+    public enum JsonTokenGenericNotEscaped
     {
         [String(doEscape:false, channel:0)] STRING = 1,
         [Lexeme(GenericToken.Double)] DOUBLE = 2,
@@ -19,7 +19,7 @@ namespace bench.json
         [Lexeme(GenericToken.KeyWord, "null")] NULL = 14
     }
     
-    public enum JsonTokenGenericStringNotEscaped
+    public enum JsonTokenGenericEscaped
     {
         [String(doEscape:true, channel:0)] STRING = 1,
         [Double(channel:0)] DOUBLE = 2,

--- a/src/samples/ParserExample/Program.cs
+++ b/src/samples/ParserExample/Program.cs
@@ -502,41 +502,188 @@ return r";
 
         }
 
-        public static void testJSON()
+        public static void testJSONEscaped(string content = null)
         {
+            if (content == null)
+            {
+                content = File.ReadAllText("test.json");
+            }
             try {
 
                 var instance = new EbnfJsonGenericParser();
             var builder = new ParserBuilder<JsonTokenGeneric, JSon>();
             var buildResult = builder.BuildParser(instance, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
-            // if (buildResult.IsOk)
-            // {
-            //     Console.WriteLine("parser built.");
-            //     var parser = buildResult.Result;
-            //     var content = File.ReadAllText("test.json");
-            //     Console.WriteLine("test.json read.");
-            //     var jsonResult = parser.Parse(content);
-            //     Console.WriteLine("json parse done.");
-            //     if (jsonResult.IsOk)
-            //     {
-            //         Console.WriteLine("YES !");
-            //     }
-            //     else
-            //     {
-            //         Console.WriteLine("Ooh no !");
-            //     }
-            //     Console.WriteLine("Done.");
-            //
-            // }
-            // else
-            // {
-            //     buildResult.Errors.ForEach(e => Console.WriteLine(e.Message));
-            // }
+            if (buildResult.IsOk)
+            {
+                Console.WriteLine("parser built.");
+                var parser = buildResult.Result;
+                
+                Console.WriteLine("test.json read.");
+                for (int i = 0; i < 10; i++)
+                {
+
+
+                    var jsonResult = parser.Parse(content);
+                    Console.WriteLine("json parse done.");
+                    if (jsonResult.IsOk)
+                    {
+                        Console.WriteLine("YES !");
+                    }
+                    else
+                    {
+                        Console.WriteLine("Ooh no !");
+                    }
+                }
+
+                Console.WriteLine("Done.");
+            
+            }
+            else
+            {
+                buildResult.Errors.ForEach(e => Console.WriteLine(e.Message));
+            }
             }
             catch(Exception e) {
                 Console.WriteLine($"ERROR {e.Message} : \n {e.StackTrace}");
             }
 
+        }
+        
+        public static void testProfileJSONEscaping(string content = null, bool escape = true)
+        {
+            if (escape)
+            {
+                if (content == null)
+                {
+                    content = File.ReadAllText("test.json");
+                }
+
+                try
+                {
+
+                    var instance = new EbnfJsonGenericParser();
+                    var builder = new ParserBuilder<JsonTokenGeneric, JSon>();
+                    var buildResult = builder.BuildParser(instance, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
+                    if (buildResult.IsOk)
+                    {
+                        Console.WriteLine("parser built.");
+                        var parser = buildResult.Result;
+
+                        Console.WriteLine("test.json read.");
+                        for (int i = 0; i < 10; i++)
+                        {
+
+
+                            var jsonResult = parser.Parse(content);
+                            Console.WriteLine("json parse done.");
+                            if (jsonResult.IsOk)
+                            {
+                                Console.WriteLine("YES !");
+                            }
+                            else
+                            {
+                                Console.WriteLine("Ooh no !");
+                            }
+                        }
+
+                        Console.WriteLine("Done.");
+
+                    }
+                    else
+                    {
+                        buildResult.Errors.ForEach(e => Console.WriteLine(e.Message));
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"ERROR {e.Message} : \n {e.StackTrace}");
+                }
+            }
+            else
+            {
+                if (content == null)
+                {
+                    content = File.ReadAllText("test.json");
+                }
+            
+                var instanceNot = new EbnfJsonGenericParserStringNotEscaped();
+                var builderNot = new ParserBuilder<JsonTokenGenericStringNotEscaped, JSon>();
+                var buildResultNot = builderNot.BuildParser(instanceNot, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
+                if (buildResultNot.IsOk)
+                {
+                    Console.WriteLine("parser built.");
+                    var parser = buildResultNot.Result;
+                
+                    Console.WriteLine("test.json read.");
+
+
+                    var jsonResult = parser.Parse(content);
+                    Console.WriteLine("json parse done.");
+                    if (jsonResult.IsOk)
+                    {
+                        Console.WriteLine("YES !");
+                    }
+                    else
+                    {
+                        Console.WriteLine("Ooh no !");
+                    }
+
+                    Console.WriteLine("Done. Unescaped.");
+            
+                }
+                else
+                {
+                    buildResultNot.Errors.ForEach(e => Console.WriteLine(e.Message));
+                }
+            }
+
+        }
+        
+        public static void testJSONNotEscaped(string content = null)
+        {
+            if (content == null)
+            {
+                content = File.ReadAllText("test.json");
+            }
+            
+            var instanceNot = new EbnfJsonGenericParserStringNotEscaped();
+            var builderNot = new ParserBuilder<JsonTokenGenericStringNotEscaped, JSon>();
+            var buildResultNot = builderNot.BuildParser(instanceNot, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
+            if (buildResultNot.IsOk)
+            {
+                Console.WriteLine("parser built.");
+                var parser = buildResultNot.Result;
+                
+                Console.WriteLine("test.json read.");
+
+
+                var jsonResult = parser.Parse(content);
+                Console.WriteLine("json parse done.");
+                if (jsonResult.IsOk)
+                {
+                    Console.WriteLine("YES !");
+                }
+                else
+                {
+                    Console.WriteLine("Ooh no !");
+                }
+
+                Console.WriteLine("Done. Unescaped.");
+            
+            }
+            else
+            {
+                buildResultNot.Errors.ForEach(e => Console.WriteLine(e.Message));
+            }
+        }
+        
+        public static void testJSONEscapedVsNotEscaped()
+        {
+            var content = File.ReadAllText("test.json");
+            
+            testJSONEscaped(content);
+
+            testJSONNotEscaped(content);
         }
 
         private static void TestGraphViz()
@@ -1204,7 +1351,8 @@ while a < 10 do
         }
         private static void Main(string[] args)
         {
-            TestIssue487();
+            //testGenericLexerJson();
+            // TestIssue487();
             //BenchSimpleExpression();
             // IndentRefactoring();
             //NodeNames();
@@ -1219,7 +1367,12 @@ while a < 10 do
             //TestContextualParser();
             //TestTokenCallBacks();
             //test104();
-            // testJSON();
+            //testJSON();
+            //testJSONEscapedVsNotEscaped();
+            //testJSONEscaped();
+            //testJSONNotEscaped();
+            // testProfileJSONEscaping(escape:true);
+            testProfileJSONEscaping(escape:false);
             //TestGrammarParser();
             // TestGraphViz();
             // TestGraphViz();

--- a/src/samples/jsonparser/EbnfJsonGenericParser.cs
+++ b/src/samples/jsonparser/EbnfJsonGenericParser.cs
@@ -141,14 +141,164 @@ namespace jsonparser
             return value;
         }
 
-        [Production("additionalProperty : COMMA property")]
-        public JSon property(Token<JsonTokenGeneric> comma, JObject property)
+        [Production("additionalProperty : COMMA[d] property")]
+        public JSon property( JObject property)
         {
             return property;
         }
 
         [Production("property: STRING COLON[d] value")]
         public JSon property(Token<JsonTokenGeneric> key, JSon value)
+        {
+            return new JObject(key.StringWithoutQuotes, value);
+        }
+
+        #endregion
+    }
+    
+     [BroadenTokenWindow]
+    [ParserRoot("root")]
+    public class EbnfJsonGenericParserStringNotEscaped
+    {
+        #region root
+
+        [Production("root : value")]
+        public JSon Root(JSon value)
+        {
+            return value;
+        }
+
+        #endregion
+
+        #region VALUE
+
+        [Production("value : STRING")]
+        public JSon StringValue(Token<JsonTokenGenericStringNotEscaped> stringToken)
+        {
+            return new JValue(stringToken.StringWithoutQuotes);
+        }
+
+        [Production("value : INT")]
+        public JSon IntValue(Token<JsonTokenGenericStringNotEscaped> intToken)
+        {
+            return new JValue(intToken.IntValue);
+        }
+
+        [Production("value : DOUBLE")]
+        public JSon DoubleValue(Token<JsonTokenGenericStringNotEscaped> doubleToken)
+        {
+            double dbl;
+            try
+            {
+                var doubleParts = doubleToken.Value.Split('.');
+                dbl = double.Parse(doubleParts[0]);
+                if (doubleParts.Length > 1)
+                {
+                    var decimalPart = double.Parse(doubleParts[1]);
+                    for (var i = 0; i < doubleParts[1].Length; i++) decimalPart = decimalPart / 10.0;
+                    dbl += decimalPart;
+                }
+            }
+            catch (Exception)
+            {
+                dbl = double.MinValue;
+            }
+
+            return new JValue(dbl);
+        }
+
+        [Production("value : BOOLEAN")]
+        public JSon BooleanValue(Token<JsonTokenGenericStringNotEscaped> boolToken)
+        {
+            return new JValue(bool.Parse(boolToken.Value));
+        }
+
+        [Production("value : NULL[d]")]
+        public JSon NullValue()
+        {
+            return new JNull();
+        }
+
+        [Production("value : object")]
+        public JSon ObjectValue(JSon value)
+        {
+            return value;
+        }
+
+        [Production("value: list")]
+        public JSon ListValue(JList list)
+        {
+            return list;
+        }
+
+        #endregion
+
+        #region OBJECT
+
+        [Production("object: ACCG[d] ACCD[d]")]
+        public JSon EmptyObjectValue()
+        {
+            return new JObject();
+        }
+
+        [Production("object: ACCG[d] members ACCD[d]")]
+        public JSon AttributesObjectValue(JObject members)
+        {
+            return members;
+        }
+
+        #endregion
+
+        #region LIST
+
+        [Production("list: CROG[d] CROD[d]")]
+        public JSon EmptyList()
+        {
+            return new JList();
+        }
+
+        [Production("list: CROG[d] listElements CROD[d]")]
+        public JSon List(JList elements)
+        {
+            return elements;
+        }
+
+
+        [Production("listElements: value additionalValue*")]
+        public JSon listElements(JSon head, List<JSon> tail)
+        {
+            var values = new JList(head);
+            values.AddRange(tail);
+            return values;
+        }
+
+        [Production("additionalValue: COMMA value")]
+        public JSon ListElementsOne(Token<JsonTokenGenericStringNotEscaped> discardedComma, JSon value)
+        {
+            return value;
+        }
+
+        #endregion
+
+        #region PROPERTIES
+
+        [Production("members: property additionalProperty*")]
+        public JSon Members(JObject head, List<JSon> tail)
+        {
+            var value = new JObject();
+            value.Merge(head);
+            foreach (var p in tail) value.Merge((JObject) p);
+            return value;
+        }
+
+        [Production("additionalProperty : COMMA property")]
+        public JSon property(Token<JsonTokenGenericStringNotEscaped> comma, JObject property)
+        {
+            return property;
+        }
+
+        [Production("property: STRING COLON[d] value")]
+        public JSon property(Token<JsonTokenGenericStringNotEscaped> key, JSon value)
         {
             return new JObject(key.StringWithoutQuotes, value);
         }

--- a/src/samples/jsonparser/JsonTokenGeneric.cs
+++ b/src/samples/jsonparser/JsonTokenGeneric.cs
@@ -4,18 +4,43 @@ namespace jsonparser
 {
     public enum JsonTokenGeneric
     {
-        [Lexeme(GenericToken.String,channel:0)] STRING = 1,
-        [Lexeme(GenericToken.Double,channel:0)] DOUBLE = 2,
+        [String(doEscape:true, channel:0)] STRING = 1,
+        [Double(channel:0)] DOUBLE = 2,
         [Lexeme(GenericToken.Int,channel:0)] INT = 3,
 
-        [Lexeme(GenericToken.KeyWord,channel:0, "true", "false")]
+        [Keyword("true", channel:0)]
+        [Keyword("false", channel:0)]
         BOOLEAN = 4,
-        [Lexeme(GenericToken.SugarToken,channel:0, "{")] ACCG = 5,
-        [Lexeme(GenericToken.SugarToken,channel:0, "}")] ACCD = 6,
-        [Lexeme(GenericToken.SugarToken,channel:0, "[")] CROG = 7,
-        [Lexeme(GenericToken.SugarToken,channel:0, "]")] CROD = 8,
-        [Lexeme(GenericToken.SugarToken,channel:0, ",")] COMMA = 9,
-        [Lexeme(GenericToken.SugarToken,channel:0, ":")] COLON = 10,
-        [Lexeme(GenericToken.KeyWord,channel:0, "null")] NULL = 14
+        [Keyword( "null",channel:0)] NULL = 14,
+        
+        
+        [Sugar("{",channel:0)] ACCG = 5,
+        [Sugar( "}",channel:0)] ACCD = 6,
+        [Sugar( "[",channel:0)] CROG = 7,
+        [Sugar( "]",channel:0)] CROD = 8,
+        [Sugar( ",",channel:0)] COMMA = 9,
+        [Sugar( ":",channel:0)] COLON = 10,
+        
+    }
+    
+    public enum JsonTokenGenericStringNotEscaped
+    {
+        [String(doEscape:true, channel:0)] STRING = 1,
+        [Double(channel:0)] DOUBLE = 2,
+        [Lexeme(GenericToken.Int,channel:0)] INT = 3,
+
+        [Keyword("true", channel:0)]
+        [Keyword("false", channel:0)]
+        BOOLEAN = 4,
+        [Keyword( "null",channel:0)] NULL = 14,
+        
+        
+        [Sugar("{",channel:0)] ACCG = 5,
+        [Sugar( "}",channel:0)] ACCD = 6,
+        [Sugar( "[",channel:0)] CROG = 7,
+        [Sugar( "]",channel:0)] CROD = 8,
+        [Sugar( ",",channel:0)] COMMA = 9,
+        [Sugar( ":",channel:0)] COLON = 10,
+        
     }
 }

--- a/src/sly/lexer/GenericLexer.cs
+++ b/src/sly/lexer/GenericLexer.cs
@@ -872,7 +872,7 @@ namespace sly.lexer
         }
 
         public void AddStringLexem(IN token, BuildResult<ILexer<IN>> result, string stringDelimiter,
-            string escapeDelimiterChar = "\\")
+            string escapeDelimiterChar = "\\", bool doEscape = true)
         {
             if (string.IsNullOrEmpty(stringDelimiter) || stringDelimiter.Length > 1) {
                 result.AddError(new LexerInitializationError(ErrorLevel.FATAL,
@@ -933,15 +933,19 @@ namespace sly.lexer
                 match.Result.SpanValue = value;
 
                 match.StringDelimiterChar = stringDelimiterChar;
-                if (stringDelimiterChar != escapeStringDelimiterChar)
+
+                if (doEscape)
                 {
-                    match.Result.SpanValue = diffCharEscaper(escapeStringDelimiterChar, stringDelimiterChar,
-                        match.Result.SpanValue);
-                }
-                else
-                {
-                    match.Result.SpanValue = sameCharEscaper(escapeStringDelimiterChar, stringDelimiterChar,
-                        match.Result.SpanValue);
+                    if (stringDelimiterChar != escapeStringDelimiterChar)
+                    {
+                        match.Result.SpanValue = diffCharEscaper(escapeStringDelimiterChar, stringDelimiterChar,
+                            match.Result.SpanValue);
+                    }
+                    else
+                    {
+                        match.Result.SpanValue = sameCharEscaper(escapeStringDelimiterChar, stringDelimiterChar,
+                            match.Result.SpanValue);
+                    }
                 }
 
                 return match;

--- a/src/sly/lexer/attributes/KeywordAttribute.cs
+++ b/src/sly/lexer/attributes/KeywordAttribute.cs
@@ -2,7 +2,7 @@ namespace sly.lexer
 {
     public class KeywordAttribute : LexemeAttribute
     {
-        public KeywordAttribute(string keyword) : base(GenericToken.KeyWord, keyword)
+        public KeywordAttribute(string keyword, int channel = Channels.Main) : base(GenericToken.KeyWord, keyword)
         {
             
         }

--- a/src/sly/lexer/attributes/StringAttribute.cs
+++ b/src/sly/lexer/attributes/StringAttribute.cs
@@ -2,7 +2,7 @@ namespace sly.lexer
 {
     public class StringAttribute : LexemeAttribute
     {
-        public StringAttribute(string delimiter = "\"", string escape = "\\") : base(GenericToken.String, delimiter, escape)
+        public StringAttribute(string delimiterChar = "\"", string escapeChar = "\\", bool doEscape = true, int channel = Channels.Main) : base(GenericToken.String, channel, delimiterChar, escapeChar, doEscape.ToString())
         {   
         } 
     }

--- a/tests/ParserTests/samples/JsonGenericTests.cs
+++ b/tests/ParserTests/samples/JsonGenericTests.cs
@@ -13,7 +13,10 @@ namespace ParserTests.samples
         {
             var jsonParser = new EbnfJsonGenericParser();
             var builder = new ParserBuilder<JsonTokenGeneric, JSon>();
-            Parser = builder.BuildParser(jsonParser, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root").Result;
+            
+            var build  = builder.BuildParser(jsonParser, ParserType.EBNF_LL_RECURSIVE_DESCENT, "root");
+            Check.That(build).IsOk();
+            Parser = build.Result;
         }
 
         private static Parser<JsonTokenGeneric, JSon> Parser;


### PR DESCRIPTION

# do not escape strings if not needed (as an opt-in for compatibility)

## How

```c#
// escape : default behavior
[String(doEscape:true, channel:0)] STRING = 1,

// do not escape
[String(doEscape:false, channel:0)] STRING = 1,

```


## Benchmark

```

BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.5011/22H2/2022Update)
Intel Core i7-10610U CPU 1.80GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK 8.0.400
  [Host]     : .NET 7.0.20 (7.0.2024.26716), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.20 (7.0.2024.26716), X64 RyuJIT AVX2


```
| Method            | Mean     | Error   | StdDev   | Median   | Gen0       | Gen1      | Gen2      | Allocated |
|------------------ |---------:|--------:|---------:|---------:|-----------:|----------:|----------:|----------:|
| escaping | 140.2 ms | 5.03 ms | 14.44 ms | 135.5 ms | 10666.6667 | 3666.6667 | 1666.6667 |  62.12 MB |
| not escaping   | 131.9 ms | 4.73 ms | 13.19 ms | 129.5 ms |  9000.0000 | 3500.0000 | 1500.0000 |   56.1 MB |


# analysis

**CPU :**

`(135.5 - 129.5) / 12.95 = 0.04`

**-4%** 👍

**Memory :**

`(62.12 - 56.1) / 56.1 = 0.107`

**-10.7%** 👍
