### PR TITLE
Add annotations for regular expressions in LexemeAttribute

### DIFF
--- a/src/sly/lexer/attributes/LexemeAttribute.cs
+++ b/src/sly/lexer/attributes/LexemeAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace sly.lexer
 {
@@ -14,7 +15,7 @@ namespace sly.lexer
         
         internal string Mode { get; set; }
         
-        public LexemeAttribute(string pattern, bool isSkippable = false, bool isLineEnding = false)
+        public LexemeAttribute([StringSyntax(StringSyntaxAttribute.Regex)] string pattern, bool isSkippable = false, bool isLineEnding = false)
         {
             Pattern = pattern;
             IsSkippable = isSkippable;
@@ -55,6 +56,7 @@ namespace sly.lexer
         
         public string IdentifierRestPattern { get; }
 
+        [StringSyntax(StringSyntaxAttribute.Regex)]
         public string Pattern { get; set; }
 
         public bool IsSkippable { get; set; }

--- a/src/sly/sly.csproj
+++ b/src/sly/sly.csproj
@@ -37,6 +37,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
+    <PackageReference Include="PolySharp" Version="1.15.0" Condition=" $(TargetFramework.StartsWith('netstandard')) OR '$(TargetFramework)' == 'net6.0'">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0"/>
     <PackageReference Include="System.ValueTuple" Version="4.6.0"/>    
   </ItemGroup>


### PR DESCRIPTION
refactor(lexer): Add annotations for regular expressions in LexemeAttribute

- Add [StringSyntax] attribute to the pattern parameter in the LexemeAttribute class
- Add [StringSyntax] attribute to the IdentifierStartPattern and IdentifierRestPattern properties
- Update the project file to add a PolySharp package reference to support string syntax analysis

Close #557