### PR TITLE
refactor(sly): add Enum constraint to token type

### DIFF
--- a/src/sly/EnumConverter.cs
+++ b/src/sly/EnumConverter.cs
@@ -17,13 +17,13 @@ namespace sly
 
 
         
-        public static IN ConvertStringToEnum<IN>(string name)  where IN : struct
+        public static IN ConvertStringToEnum<IN>(string name)  where IN : struct, Enum
         {
             Enum.TryParse(name, out IN token);
             return token;
         }
         
-        public static bool IsEnumValue<IN>(string name)  where IN : struct
+        public static bool IsEnumValue<IN>(string name)  where IN : struct, Enum
         {
             return Enum.TryParse(name, out IN token);
         }

--- a/src/sly/lexer/CallBacksBuilder.cs
+++ b/src/sly/lexer/CallBacksBuilder.cs
@@ -8,7 +8,7 @@ namespace sly.lexer
     public static class CallBacksBuilder
     {
 
-        public static void BuildCallbacks<IN>(GenericLexer<IN> lexer) where IN : struct
+        public static void BuildCallbacks<IN>(GenericLexer<IN> lexer) where IN : struct, Enum
         {
             var attributes =
                 (CallBacksAttribute[]) typeof(IN).GetCustomAttributes(typeof(CallBacksAttribute), true);
@@ -20,7 +20,7 @@ namespace sly.lexer
 
         }
 
-        public static void ExtractCallBacks<IN>(Type callbackClass, GenericLexer<IN> lexer) where IN : struct
+        public static void ExtractCallBacks<IN>(Type callbackClass, GenericLexer<IN> lexer) where IN : struct, Enum
         {
             var methods = callbackClass.GetMethods().ToList();
             methods = methods.Where<MethodInfo>(m =>
@@ -37,13 +37,13 @@ namespace sly.lexer
             }
         }
 
-        public static void AddCallback<IN>(GenericLexer<IN> lexer, MethodInfo method, IN token) where IN : struct
+        public static void AddCallback<IN>(GenericLexer<IN> lexer, MethodInfo method, IN token) where IN : struct, Enum
         {
             var callbackDelegate = (Func<Token<IN>,Token<IN>>)Delegate.CreateDelegate(typeof(Func<Token<IN>,Token<IN>>), method);
             lexer.AddCallBack(token,callbackDelegate);
         }
         
-        public static List<(IN tokenId,Func<Token<IN>, Token<IN>> callback)> GetCallbacks<IN>(GenericLexer<IN> lexer) where IN : struct
+        public static List<(IN tokenId,Func<Token<IN>, Token<IN>> callback)> GetCallbacks<IN>(GenericLexer<IN> lexer) where IN : struct, Enum
         {
             List<(IN,Func<Token<IN>, Token<IN>>)> callbacks = new List<(IN,Func<Token<IN>, Token<IN>>)>();
             var classAttributes =

--- a/src/sly/lexer/GenericLexer.cs
+++ b/src/sly/lexer/GenericLexer.cs
@@ -9,7 +9,7 @@ using sly.lexer.fsm.transitioncheck;
 
 namespace sly.lexer
 {
-    public class GenericLexer<IN> : ILexer<IN> where IN : struct
+    public class GenericLexer<IN> : ILexer<IN> where IN : struct, Enum
     {
         public class Config
         {

--- a/src/sly/lexer/ILexer.cs
+++ b/src/sly/lexer/ILexer.cs
@@ -5,7 +5,7 @@ using sly.lexer.fsm;
 
 namespace sly.lexer
 {
-    public interface ILexer<T> where T : struct
+    public interface ILexer<T> where T : struct, Enum
     {
         
         Dictionary<T, Dictionary<string, string>> LexemeLabels { get; set; }

--- a/src/sly/lexer/Lexer.cs
+++ b/src/sly/lexer/Lexer.cs
@@ -10,7 +10,7 @@ namespace sly.lexer
     ///     T is the token type
     /// </summary>
     /// <typeparam name="T">T is the enum Token type</typeparam>
-    public class Lexer<T> : ILexer<T> where T : struct
+    public class Lexer<T> : ILexer<T> where T : struct, Enum
     {
         public Dictionary<T, Dictionary<string, string>> LexemeLabels { get; set; }
         public string I18n { get; set; }

--- a/src/sly/lexer/LexerAttribute.cs
+++ b/src/sly/lexer/LexerAttribute.cs
@@ -2,10 +2,14 @@ using System;
 
 namespace sly.lexer
 {
+
     [AttributeUsage(AttributeTargets.Enum)]
     public class LexerAttribute : Attribute
     {
-        private static readonly GenericLexer<int>.Config Defaults = new GenericLexer<int>.Config();
+        private enum DefaultEnum : int
+        {
+        }
+        private static readonly GenericLexer<DefaultEnum>.Config Defaults = new GenericLexer<DefaultEnum>.Config();
 
         private bool? ignoreWS;
 

--- a/src/sly/lexer/LexerBuilder.cs
+++ b/src/sly/lexer/LexerBuilder.cs
@@ -45,13 +45,13 @@ namespace sly.lexer
 
     public delegate (List<string> modes, bool isModePopper, string pushTarget) ModesForLexemeGetter<IN>(
         KeyValuePair<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)> attribute)
-        where IN : struct;
+        where IN : struct, Enum;
     
     public static class LexerBuilder
     {
         
         public static Dictionary<IN, (List<LexemeAttribute>,List<LexemeLabelAttribute>)> GetLexemesWithReflection<IN>(BuildResult<ILexer<IN>> result, string lang)
-            where IN : struct
+            where IN : struct, Enum
         {
             var attributes = new Dictionary<IN, (List<LexemeAttribute>,List<LexemeLabelAttribute>)>();
 
@@ -101,7 +101,7 @@ namespace sly.lexer
 
         public static BuildResult<ILexer<IN>> BuildLexer<IN>(
             Action<IN, LexemeAttribute, GenericLexer<IN>> extensionBuilder = null,
-            LexerPostProcess<IN> lexerPostProcess = null) where IN : struct
+            LexerPostProcess<IN> lexerPostProcess = null) where IN : struct, Enum
         {
             return BuildLexer<IN>(new BuildResult<ILexer<IN>>(), extensionBuilder, lexerPostProcess: lexerPostProcess);
         }
@@ -115,7 +115,7 @@ namespace sly.lexer
             Dictionary<IN,List<CommentAttribute>> comments = null,
             Func<KeyValuePair<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)>,(List<string> modes, bool isModePopper, string pushTarget)> modesGetter = null,
             Func<List<(IN tokenId, Func<Token<IN>, Token<IN>> callback)>> callbacksGetter = null)
-            where IN : struct
+            where IN : struct, Enum
         {
             attributes = attributes ?? GetLexemesWithReflection<IN>(result, lang);
             lexerAttribute = lexerAttribute ?? typeof(IN).GetCustomAttribute<LexerAttribute>();
@@ -143,7 +143,7 @@ namespace sly.lexer
             return result;
         }
 
-        private static List<Token<IN>> LabelTokens<IN>(string lang, List<Token<IN>> tokens, Dictionary<IN, Dictionary<string, string>> labels) where IN : struct
+        private static List<Token<IN>> LabelTokens<IN>(string lang, List<Token<IN>> tokens, Dictionary<IN, Dictionary<string, string>> labels) where IN : struct, Enum
         {
             List<Token<IN>> labeledTokens;
             labeledTokens = tokens.Select(token =>
@@ -175,7 +175,7 @@ namespace sly.lexer
             string lang = null,
             IList<string> explicitTokens = null, Dictionary<IN, List<CommentAttribute>> comments = null,
             Func<KeyValuePair<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)>, (List<string>
-                modes, bool isModePopper, string pushTarget)> modesGetter = null,  Func<List<(IN tokenId, Func<Token<IN>, Token<IN>> callback)>> callbacksGetter = null) where IN : struct
+                modes, bool isModePopper, string pushTarget)> modesGetter = null,  Func<List<(IN tokenId, Func<Token<IN>, Token<IN>> callback)>> callbacksGetter = null) where IN : struct, Enum
         {
             var hasRegexLexemes = IsRegexLexer<IN>(attributes);
             var hasGenericLexemes = IsGenericLexer<IN>(attributes);
@@ -214,7 +214,7 @@ namespace sly.lexer
 
         private static BuildResult<ILexer<IN>> SetLabels<IN>(
             Dictionary<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)> attributes,
-            BuildResult<ILexer<IN>> result) where IN : struct
+            BuildResult<ILexer<IN>> result) where IN : struct, Enum
         {
             if (result.IsOk && result.Result != null)
             {
@@ -269,7 +269,7 @@ namespace sly.lexer
         private static BuildResult<ILexer<IN>> BuildRegexLexer<IN>(
             Dictionary<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)> attributes,
             string lang,
-            BuildResult<ILexer<IN>> result) where IN : struct
+            BuildResult<ILexer<IN>> result) where IN : struct, Enum
         {
             var lexer = new Lexer<IN>()
             {
@@ -314,7 +314,7 @@ namespace sly.lexer
         
         
         private static Dictionary<string, IDictionary<IN, List<LexemeAttribute>>> GetSubLexers<IN>(
-            IDictionary<IN, (List<LexemeAttribute> lexemes,List<LexemeLabelAttribute> labels)> attributes, Func<KeyValuePair<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)>,(List<string> modes, bool isModePopper, string pushTarget)> modesGetter = null) where IN : struct
+            IDictionary<IN, (List<LexemeAttribute> lexemes,List<LexemeLabelAttribute> labels)> attributes, Func<KeyValuePair<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)>,(List<string> modes, bool isModePopper, string pushTarget)> modesGetter = null) where IN : struct, Enum
         {
             if (modesGetter == null)
             {
@@ -354,7 +354,7 @@ namespace sly.lexer
             return subLexers;
         }
 
-        private static (List<string> modes,bool isModePopper, string pushTarget) GetModesForLexeme<IN>(KeyValuePair<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)> attribute) where IN : struct
+        private static (List<string> modes,bool isModePopper, string pushTarget) GetModesForLexeme<IN>(KeyValuePair<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)> attribute) where IN : struct, Enum
         {
             (List<string> modes, bool isModePopper, string pushTarget) result = (new List<string>(), false, null);
             if (attribute.Key is Enum enumValue)
@@ -403,7 +403,7 @@ namespace sly.lexer
 
         private static (GenericLexer<IN>.Config, GenericToken[]) GetConfigAndGenericTokens<IN>(
             IDictionary<IN, List<LexemeAttribute>> attributes, LexerAttribute lexerAttribute = null)
-            where IN : struct
+            where IN : struct, Enum
         {
             var config = new GenericLexer<IN>.Config();
             if (lexerAttribute != null)
@@ -460,7 +460,7 @@ namespace sly.lexer
         }
 
         private static NodeCallback<GenericToken> GetCallbackSingle<IN>(IN token, int channel)
-            where IN : struct
+            where IN : struct, Enum
         {
             NodeCallback<GenericToken> callback = match =>
             {
@@ -474,7 +474,7 @@ namespace sly.lexer
         }
 
         private static NodeCallback<GenericToken> GetCallbackMulti<IN>(IN token, int channel)
-            where IN : struct
+            where IN : struct, Enum
         {
             NodeCallback<GenericToken> callbackMulti = match =>
             {
@@ -494,7 +494,7 @@ namespace sly.lexer
             IList<string> explicitTokens = null, LexerAttribute lexerAttribute = null,
             Dictionary<IN, List<CommentAttribute>> comments = null,
             Func<KeyValuePair<IN, (List<LexemeAttribute> lexemes, List<LexemeLabelAttribute> labels)>, (List<string>
-                modes, bool isModePopper, string pushTarget)> modesGetter = null, Func<List<(IN tokenId, Func<Token<IN>, Token<IN>> callback) >> callbacksGetter = null) where IN : struct
+                modes, bool isModePopper, string pushTarget)> modesGetter = null, Func<List<(IN tokenId, Func<Token<IN>, Token<IN>> callback) >> callbacksGetter = null) where IN : struct, Enum
         {
             GenericLexer<IN> genLexer = null;
             var subLexers = GetSubLexers(attributes, modesGetter);
@@ -534,7 +534,7 @@ namespace sly.lexer
         private static BuildResult<ILexer<IN>> BuildGenericLexer<IN>(IDictionary<IN, List<LexemeAttribute>> attributes,
             Action<IN, LexemeAttribute, GenericLexer<IN>> extensionBuilder, BuildResult<ILexer<IN>> result, string lang,
             LexerAttribute lexerAttribute = null, Dictionary<IN, List<CommentAttribute>> comments = null,
-            IList<string> explicitTokens = null) where IN : struct
+            IList<string> explicitTokens = null) where IN : struct, Enum
         {
             result = CheckStringAndCharTokens<IN>(attributes, result, lang);
             var (config, tokens) = GetConfigAndGenericTokens<IN>(attributes, lexerAttribute);
@@ -783,7 +783,7 @@ namespace sly.lexer
 
         private static BuildResult<ILexer<IN>> CheckStringAndCharTokens<IN>(
             IDictionary<IN, List<LexemeAttribute>> attributes, BuildResult<ILexer<IN>> result, string lang)
-            where IN : struct
+            where IN : struct, Enum
         {
             var allLexemes = attributes.Values.SelectMany<List<LexemeAttribute>, LexemeAttribute>(a => a);
 
@@ -809,7 +809,7 @@ namespace sly.lexer
 
 
         private static Dictionary<IN, List<CommentAttribute>> GetCommentsAttribute<IN>(BuildResult<ILexer<IN>> result,
-            string lang) where IN : struct
+            string lang) where IN : struct, Enum
         {
             var attributes = new Dictionary<IN, List<CommentAttribute>>();
 
@@ -861,7 +861,7 @@ namespace sly.lexer
         }
 
         private static void AddExtensions<IN>(Dictionary<IN, LexemeAttribute> extensions,
-            Action<IN, LexemeAttribute, GenericLexer<IN>> extensionBuilder, GenericLexer<IN> lexer) where IN : struct
+            Action<IN, LexemeAttribute, GenericLexer<IN>> extensionBuilder, GenericLexer<IN> lexer) where IN : struct, Enum
         {
             if (extensionBuilder != null)
             {

--- a/src/sly/lexer/LexerResult.cs
+++ b/src/sly/lexer/LexerResult.cs
@@ -1,9 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace sly.lexer
 {
-    public class LexerResult<IN> where IN : struct
+    public class LexerResult<IN> where IN : struct, Enum
     {
         public bool IsError { get; set; }
 

--- a/src/sly/lexer/Token.cs
+++ b/src/sly/lexer/Token.cs
@@ -15,7 +15,7 @@ namespace sly.lexer
     }
 
     [DebuggerDisplay("{TokenID} : {Value} - {IsExplicit}")]
-    public class Token<T> where T:struct
+    public class Token<T> where T:struct, Enum
     {
         
         

--- a/src/sly/lexer/TokenChannel.cs
+++ b/src/sly/lexer/TokenChannel.cs
@@ -2,10 +2,11 @@ using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System;
 
 namespace sly.lexer
 {
-    public class TokenChannel<IN>  where IN : struct
+    public class TokenChannel<IN>  where IN : struct, Enum
     {
         public readonly List<Token<IN>> Tokens;
 

--- a/src/sly/lexer/TokenChannels.cs
+++ b/src/sly/lexer/TokenChannels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -15,7 +16,7 @@ namespace sly.lexer
         public const int Comments = 2;
     }
     
-    public class TokenChannels<IN> : IEnumerable<Token<IN>>  where IN : struct
+    public class TokenChannels<IN> : IEnumerable<Token<IN>>  where IN : struct, Enum
     {
         
         

--- a/src/sly/lexer/fluent/FluentLexerBuilder.cs
+++ b/src/sly/lexer/fluent/FluentLexerBuilder.cs
@@ -7,7 +7,7 @@ using sly.lexer.fsm;
 
 namespace sly.lexer.fluent;
 
-public class FluentLexerBuilder<IN> :  IFluentLexemeBuilder<IN> where IN : struct
+public class FluentLexerBuilder<IN> :  IFluentLexemeBuilder<IN> where IN : struct, Enum
 {
     private bool _ignoreWs = true;
 

--- a/src/sly/lexer/fluent/IFluentLexemeBuilder.cs
+++ b/src/sly/lexer/fluent/IFluentLexemeBuilder.cs
@@ -5,7 +5,7 @@ using sly.lexer.fsm;
 
 namespace sly.lexer.fluent;
 
-public interface IFluentLexemeBuilder<IN> : IFluentLexerBuilder<IN> where IN : struct {
+public interface IFluentLexemeBuilder<IN> : IFluentLexerBuilder<IN> where IN : struct, Enum {
     
     IFluentLexemeBuilder<IN> WithLabel(string lang, string label);
     

--- a/src/sly/lexer/fluent/IFluentLexerBuilder.cs
+++ b/src/sly/lexer/fluent/IFluentLexerBuilder.cs
@@ -7,7 +7,7 @@ namespace sly.lexer.fluent;
 
 
 
-public interface IFluentLexerBuilder<IN> where IN : struct
+public interface IFluentLexerBuilder<IN> where IN : struct, Enum
 {
     
     public IFluentLexemeBuilder<IN> Double(IN tokenId, string decimalDelimiter = ".");

--- a/src/sly/lexer/fsm/FSMLexer.cs
+++ b/src/sly/lexer/fsm/FSMLexer.cs
@@ -19,9 +19,9 @@ namespace sly.lexer.fsm
         }
     }
 
-    public delegate List<Token<IN>> LexerPostProcess<IN>(List<Token<IN>> tokens) where IN : struct;
+    public delegate List<Token<IN>> LexerPostProcess<IN>(List<Token<IN>> tokens) where IN : struct, Enum;
 
-    public class FSMLexer<N> where N : struct
+    public class FSMLexer<N> where N : struct, Enum
     {
         public string Mode { get; set; }
 

--- a/src/sly/lexer/fsm/FSMLexerBuilder.cs
+++ b/src/sly/lexer/fsm/FSMLexerBuilder.cs
@@ -5,11 +5,11 @@ using sly.lexer.fsm.transitioncheck;
 
 namespace sly.lexer.fsm
 {
-    public delegate FSMMatch<IN> NodeCallback<IN>(FSMMatch<IN> node)  where IN : struct;
+    public delegate FSMMatch<IN> NodeCallback<IN>(FSMMatch<IN> node)  where IN : struct, Enum;
 
     public delegate bool TransitionPrecondition(ReadOnlyMemory<char> value);
 
-    public class FSMLexerBuilder<N>  where N : struct
+    public class FSMLexerBuilder<N>  where N : struct, Enum
     {
         private int CurrentState;
 

--- a/src/sly/lexer/fsm/FSMMatch.cs
+++ b/src/sly/lexer/fsm/FSMMatch.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace sly.lexer.fsm
 {
-    public class FSMMatch<N>  where N : struct
+    public class FSMMatch<N>  where N : struct, Enum
     {
         public Dictionary<string, object> Properties { get; }
 

--- a/src/sly/parser/fluent/FluentEBNFParserBuilder.cs
+++ b/src/sly/parser/fluent/FluentEBNFParserBuilder.cs
@@ -10,7 +10,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser.generator;
 
-public class FluentEBNFParserBuilder<IN, OUT> : IFluentEbnfRuleBuilder<IN, OUT> where IN : struct
+public class FluentEBNFParserBuilder<IN, OUT> : IFluentEbnfRuleBuilder<IN, OUT> where IN : struct, Enum
 {
     readonly Dictionary<string, NonTerminal<IN,OUT>> _nonTerminals = new ();
 

--- a/src/sly/parser/fluent/FluentParserBuilder.cs
+++ b/src/sly/parser/fluent/FluentParserBuilder.cs
@@ -13,7 +13,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser.fluent;
 
-public class FluentParserBuilder<IN, OUT> : IFluentParserBuilder<IN,OUT> where IN : struct
+public class FluentParserBuilder<IN, OUT> : IFluentParserBuilder<IN,OUT> where IN : struct, Enum
 {
     readonly Dictionary<string, NonTerminal<IN,OUT>> _nonTerminals = new Dictionary<string, NonTerminal<IN,OUT>>();
 

--- a/src/sly/parser/fluent/FluentRuleParser.cs
+++ b/src/sly/parser/fluent/FluentRuleParser.cs
@@ -1,3 +1,5 @@
+using System;
+
 using sly.buildresult;
 using sly.lexer;
 using sly.lexer.fluent;
@@ -6,7 +8,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser.fluent;
 
-public class FluentRuleParser<IN, OUT> where IN : struct
+public class FluentRuleParser<IN, OUT> where IN : struct, Enum
 {
     public IFluentLexerBuilder<EbnfTokenGeneric> GetEbnfLexerBuilder()
     {

--- a/src/sly/parser/fluent/IFluentEbnfParserBuilder.cs
+++ b/src/sly/parser/fluent/IFluentEbnfParserBuilder.cs
@@ -4,7 +4,7 @@ using sly.lexer.fluent;
 
 namespace sly.parser.generator;
 
-public interface IFluentEbnfRuleBuilder<IN, OUT> : IFluentEbnfParserBuilder<IN, OUT> where IN : struct
+public interface IFluentEbnfRuleBuilder<IN, OUT> : IFluentEbnfParserBuilder<IN, OUT> where IN : struct, Enum
 {
     public IFluentEbnfParserBuilder<IN, OUT> Named(string name);
     
@@ -13,7 +13,7 @@ public interface IFluentEbnfRuleBuilder<IN, OUT> : IFluentEbnfParserBuilder<IN, 
     public IFluentEbnfParserBuilder<IN, OUT> WithSubNodeNamed(params string[] subNodeNames);
 }
 
-public interface IFluentEbnfParserBuilder<IN,OUT> where IN : struct
+public interface IFluentEbnfParserBuilder<IN,OUT> where IN : struct, Enum
 {
 
     IFluentEbnfParserBuilder<IN, OUT> UseMemoization(bool use = true);

--- a/src/sly/parser/fluent/IFluentParserBuilder.cs
+++ b/src/sly/parser/fluent/IFluentParserBuilder.cs
@@ -7,7 +7,7 @@ using sly.parser.generator;
 
 namespace sly.parser.fluent;
 
-public interface IFluentParserBuilder<IN,OUT> where IN : struct
+public interface IFluentParserBuilder<IN,OUT> where IN : struct, Enum
 {
 
     IFluentParserBuilder<IN, OUT> UseMemoization(bool use = true);

--- a/src/sly/parser/generator/EBNFParserBuilder.cs
+++ b/src/sly/parser/generator/EBNFParserBuilder.cs
@@ -16,7 +16,7 @@ namespace sly.parser.generator
     /// <summary>
     ///     this class provides API to build parser
     /// </summary>
-    internal class EBNFParserBuilder<IN, OUT> : ParserBuilder<IN, OUT> where IN : struct
+    internal class EBNFParserBuilder<IN, OUT> : ParserBuilder<IN, OUT> where IN : struct, Enum
     {
         public EBNFParserBuilder(string i18n = null) : base(i18n)
         {

--- a/src/sly/parser/generator/ExpressionRulesGenerator.cs
+++ b/src/sly/parser/generator/ExpressionRulesGenerator.cs
@@ -9,7 +9,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser.generator
 {
-    public class ExpressionRulesGenerator<IN,OUT> where IN : struct
+    public class ExpressionRulesGenerator<IN,OUT> where IN : struct, Enum
     {
         public string I18n { get; set; }
         

--- a/src/sly/parser/generator/LeftRecursionChecker.cs
+++ b/src/sly/parser/generator/LeftRecursionChecker.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using sly.parser.syntax.grammar;
 
 namespace sly.parser.generator
 {
-    public class LeftRecursionChecker<IN,OUT> where IN : struct
+    public class LeftRecursionChecker<IN,OUT> where IN : struct, Enum
     {
         public LeftRecursionChecker()
         {

--- a/src/sly/parser/generator/NonTerminal.cs
+++ b/src/sly/parser/generator/NonTerminal.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
@@ -6,7 +7,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser.generator
 {
-    public class NonTerminal<IN, OUT> where IN : struct
+    public class NonTerminal<IN, OUT> where IN : struct, Enum
     {
         public NonTerminal(string name, List<Rule<IN, OUT>> rules)
         {

--- a/src/sly/parser/generator/OperationAttribute.cs
+++ b/src/sly/parser/generator/OperationAttribute.cs
@@ -20,7 +20,7 @@ namespace sly.parser.generator
 
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    public class OperationAttribute : Attribute //where IN : struct
+    public class OperationAttribute : Attribute //where IN : struct, Enum
     {
         /// <summary>
         ///     token as an int as attribute can not be generics.

--- a/src/sly/parser/generator/OperationMetaData.cs
+++ b/src/sly/parser/generator/OperationMetaData.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace sly.parser.generator
 {
-    public class OperationMetaData<IN, OUT> where IN : struct
+    public class OperationMetaData<IN, OUT> where IN : struct, Enum
     {
         public OperationMetaData(int precedence, Associativity assoc, MethodInfo method, Affix affix, IN oper, string nodeName = null)
         {

--- a/src/sly/parser/generator/ParserBuilder.cs
+++ b/src/sly/parser/generator/ParserBuilder.cs
@@ -17,7 +17,7 @@ namespace sly.parser.generator
     /// <summary>
     ///     this class provides API to build parser
     /// </summary>
-    public class ParserBuilder<IN, OUT> where IN : struct
+    public class ParserBuilder<IN, OUT> where IN : struct, Enum
     {
         #region API
 

--- a/src/sly/parser/generator/ParserConfiguration.cs
+++ b/src/sly/parser/generator/ParserConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
@@ -6,7 +7,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser.generator
 {
-    public class ParserConfiguration<IN, OUT> where IN : struct
+    public class ParserConfiguration<IN, OUT> where IN : struct, Enum
     {
         public string StartingRule { get; set; }
         public Dictionary<string, NonTerminal<IN, OUT>> NonTerminals { get; set; }

--- a/src/sly/parser/generator/RuleParser.cs
+++ b/src/sly/parser/generator/RuleParser.cs
@@ -4,7 +4,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser.generator
 {
-     public class RuleParser<IN,OUT> where IN : struct
+     public class RuleParser<IN,OUT> where IN : struct, Enum
     {
         #region rules grammar
 

--- a/src/sly/parser/generator/visitor/ConcreteSyntaxTreeWalker.cs
+++ b/src/sly/parser/generator/visitor/ConcreteSyntaxTreeWalker.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using sly.lexer;
@@ -5,7 +6,7 @@ using sly.parser.syntax.tree;
 
 namespace sly.parser.generator.visitor
 {
-    public class ConcreteSyntaxTreeWalker<IN, OUT, TREE_OUT> where IN : struct
+    public class ConcreteSyntaxTreeWalker<IN, OUT, TREE_OUT> where IN : struct, Enum
     {
         
         public IConcreteSyntaxTreeVisitor<IN,OUT, TREE_OUT> Visitor { get; set; }

--- a/src/sly/parser/generator/visitor/EBNFSyntaxTreeVisitor.cs
+++ b/src/sly/parser/generator/visitor/EBNFSyntaxTreeVisitor.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace sly.parser.generator.visitor
 {
-    public class EBNFSyntaxTreeVisitor<IN, OUT> : SyntaxTreeVisitor<IN, OUT> where IN : struct
+    public class EBNFSyntaxTreeVisitor<IN, OUT> : SyntaxTreeVisitor<IN, OUT> where IN : struct, Enum
     {
         public EBNFSyntaxTreeVisitor(ParserConfiguration<IN, OUT> conf, object parserInstance) : base(conf,
             parserInstance)

--- a/src/sly/parser/generator/visitor/GraphVizEBNFSyntaxTreeVisitor.cs
+++ b/src/sly/parser/generator/visitor/GraphVizEBNFSyntaxTreeVisitor.cs
@@ -8,7 +8,7 @@ using sly.parser.syntax.tree;
 namespace sly.parser.generator.visitor
 {
     [ExcludeFromCodeCoverage]
-    public class GraphVizEBNFSyntaxTreeVisitor<IN, OUT>  : IConcreteSyntaxTreeVisitor<IN, OUT, DotNode> where IN : struct
+    public class GraphVizEBNFSyntaxTreeVisitor<IN, OUT>  : IConcreteSyntaxTreeVisitor<IN, OUT, DotNode> where IN : struct, Enum
     {
         public DotGraph Graph { get; private set; }
 

--- a/src/sly/parser/generator/visitor/IConcreteSyntaxTreeVisitor.cs
+++ b/src/sly/parser/generator/visitor/IConcreteSyntaxTreeVisitor.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using sly.lexer;
 using sly.parser.syntax.tree;
 
 namespace sly.parser.generator.visitor
 {
-    public interface IConcreteSyntaxTreeVisitor<IN,OUT, TREE_OUT> where IN : struct
+    public interface IConcreteSyntaxTreeVisitor<IN,OUT, TREE_OUT> where IN : struct, Enum
     {
         TREE_OUT VisitOptionNode(bool exists, TREE_OUT child);
         TREE_OUT VisitNode(SyntaxNode<IN, OUT> node, IList<TREE_OUT> children);

--- a/src/sly/parser/generator/visitor/MermaidEBNFSyntaxTreeVisitor.cs
+++ b/src/sly/parser/generator/visitor/MermaidEBNFSyntaxTreeVisitor.cs
@@ -9,7 +9,7 @@ using sly.parser.syntax.tree;
 namespace sly.parser.generator.visitor
 {
     [ExcludeFromCodeCoverage]
-    public class MermaidEBNFSyntaxTreeVisitor<IN, OUT>  : IConcreteSyntaxTreeVisitor<IN, OUT, MermaidNode> where IN : struct
+    public class MermaidEBNFSyntaxTreeVisitor<IN, OUT>  : IConcreteSyntaxTreeVisitor<IN, OUT, MermaidNode> where IN : struct, Enum
     {
         public MermaidGraph Graph { get; private set; }
 

--- a/src/sly/parser/generator/visitor/SyntaxTreeVisitor.cs
+++ b/src/sly/parser/generator/visitor/SyntaxTreeVisitor.cs
@@ -8,7 +8,7 @@ using static sly.parser.parser.ValueOptionConstructors;
 
 namespace sly.parser.generator.visitor
 {
-    public class SyntaxVisitorResult<IN, OUT> where IN : struct
+    public class SyntaxVisitorResult<IN, OUT> where IN : struct, Enum
     {
         public List<Group<IN, OUT>> GroupListResult;
 
@@ -126,7 +126,7 @@ namespace sly.parser.generator.visitor
 
     }
 
-    public class SyntaxTreeVisitor<IN, OUT> where IN : struct
+    public class SyntaxTreeVisitor<IN, OUT> where IN : struct, Enum
     {
         public SyntaxTreeVisitor(ParserConfiguration<IN, OUT> conf, object parserInstance)
         {

--- a/src/sly/parser/parser/Group.cs
+++ b/src/sly/parser/parser/Group.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -5,7 +6,7 @@ using sly.lexer;
 
 namespace sly.parser.parser
 {
-    public class Group<IN, OUT> where IN : struct
+    public class Group<IN, OUT> where IN : struct, Enum
     {
         public readonly List<GroupItem<IN, OUT>> Items;
 

--- a/src/sly/parser/parser/GroupItem.cs
+++ b/src/sly/parser/parser/GroupItem.cs
@@ -4,7 +4,7 @@ using sly.lexer;
 
 namespace sly.parser.parser
 {
-    public class GroupItem<IN, OUT> where IN : struct
+    public class GroupItem<IN, OUT> where IN : struct, Enum
     {
         public string Name;
 

--- a/src/sly/parser/parser/ISyntaxParser.cs
+++ b/src/sly/parser/parser/ISyntaxParser.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using sly.lexer;
 using sly.parser.generator;
 
 namespace sly.parser
 {
-    public interface ISyntaxParser<IN, OUT> where IN : struct
+    public interface ISyntaxParser<IN, OUT> where IN : struct, Enum
     {
         string StartingNonTerminal { get; set; }
         

--- a/src/sly/parser/parser/ParseResult.cs
+++ b/src/sly/parser/parser/ParseResult.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using sly.parser.syntax.tree;
 
 namespace sly.parser
 {
-    public class ParseResult<IN, OUT> where IN : struct
+    public class ParseResult<IN, OUT> where IN : struct, Enum
     {
         public OUT Result { get; set; }
         

--- a/src/sly/parser/parser/Parser.cs
+++ b/src/sly/parser/parser/Parser.cs
@@ -14,7 +14,7 @@ using sly.parser.syntax.tree;
 
 namespace sly.parser
 {
-    public class Parser<IN, OUT> where IN : struct
+    public class Parser<IN, OUT> where IN : struct, Enum
     {   
 
         public Dictionary<IN, Dictionary<string, string>> LexemeLabels => Lexer.LexemeLabels;

--- a/src/sly/parser/parser/SyntaxParseResult.cs
+++ b/src/sly/parser/parser/SyntaxParseResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using sly.parser.syntax.grammar;
@@ -5,7 +6,7 @@ using sly.parser.syntax.tree;
 
 namespace sly.parser
 {
-    public class SyntaxParseResult<IN, OUT> where IN : struct
+    public class SyntaxParseResult<IN, OUT> where IN : struct, Enum
     {
         public ISyntaxNode<IN, OUT> Root { get; set; }
 

--- a/src/sly/parser/parser/SyntaxParsingContext.cs
+++ b/src/sly/parser/parser/SyntaxParsingContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using sly.parser.syntax.grammar;
@@ -5,7 +6,7 @@ using sly.parser.syntax.grammar;
 namespace sly.parser
 {
     
-    public class SyntaxParsingContext<IN, OUT> where IN : struct
+    public class SyntaxParsingContext<IN, OUT> where IN : struct, Enum
     {
         private readonly Dictionary<string, SyntaxParseResult<IN, OUT>> _memoizedNonTerminalResults = new Dictionary<string, SyntaxParseResult<IN, OUT>>();
 

--- a/src/sly/parser/parser/SyntaxTreeCleaner.cs
+++ b/src/sly/parser/parser/SyntaxTreeCleaner.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using sly.parser.syntax.tree;
 
 namespace sly.parser.parser
 {
-    public class SyntaxTreeCleaner<IN, OUT> where IN : struct
+    public class SyntaxTreeCleaner<IN, OUT> where IN : struct, Enum
     {
         public SyntaxParseResult<IN, OUT> CleanSyntaxTree(SyntaxParseResult<IN, OUT> result)
         {

--- a/src/sly/parser/parser/UnexpectedTokenSyntaxError.cs
+++ b/src/sly/parser/parser/UnexpectedTokenSyntaxError.cs
@@ -9,7 +9,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser
 {
-    public class UnexpectedTokenSyntaxError<T> : ParseError, IComparable where T : struct
+    public class UnexpectedTokenSyntaxError<T> : ParseError, IComparable where T : struct, Enum
     {
         private readonly string _i18N;
 

--- a/src/sly/parser/parser/ValueOption.cs
+++ b/src/sly/parser/parser/ValueOption.cs
@@ -9,7 +9,7 @@ namespace sly.parser.parser
             return new ValueOption<T>();
         }
 
-        public static ValueOption<Group<IN, OUT>> NoneGroup<IN, OUT>()  where IN : struct
+        public static ValueOption<Group<IN, OUT>> NoneGroup<IN, OUT>()  where IN : struct, Enum
         {
             var noneGroup = new ValueOption<Group<IN,OUT>>(true);
             return noneGroup;

--- a/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParser.Expressions.cs
+++ b/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParser.Expressions.cs
@@ -1,10 +1,12 @@
+using System;
+
 using sly.parser.generator;
 using sly.parser.syntax.grammar;
 using sly.parser.syntax.tree;
 
 namespace sly.parser.llparser.bnf;
 
-public partial class RecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+public partial class RecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
 {
     
             protected SyntaxNode<IN, OUT> ManageExpressionRules(Rule<IN, OUT> rule, SyntaxNode<IN, OUT> node)

--- a/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParser.NonTerminal.cs
+++ b/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParser.NonTerminal.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using sly.lexer;
@@ -5,7 +6,7 @@ using sly.parser.syntax.grammar;
 
 namespace sly.parser.llparser.bnf;
 
-public partial class RecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+public partial class RecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
 {
     #region parsing
 

--- a/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParser.Terminal.cs
+++ b/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParser.Terminal.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using sly.lexer;
 using sly.parser.syntax.grammar;
@@ -5,7 +6,7 @@ using sly.parser.syntax.tree;
 
 namespace sly.parser.llparser.bnf;
 
-public partial class RecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+public partial class RecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
 {
     #region parsing
 

--- a/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParser.cs
+++ b/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParser.cs
@@ -4,10 +4,11 @@ using sly.parser.generator;
 using sly.parser.syntax.grammar;
 using sly.parser.syntax.tree;
 using System.Linq;
+using System;
 
 namespace sly.parser.llparser.bnf
 {
-    public partial class RecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+    public partial class RecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
     {
         public RecursiveDescentSyntaxParser(ParserConfiguration<IN, OUT> configuration, string startingNonTerminal,
             string i18n)

--- a/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParserStarter.cs
+++ b/src/sly/parser/parser/llparser/bnf/RecursiveDescentSyntaxParserStarter.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using sly.parser.generator;
 using sly.parser.syntax.grammar;
 
 namespace sly.parser.llparser.bnf
 {
-    public partial class RecursiveDescentSyntaxParser<IN, OUT> : ISyntaxParser<IN, OUT> where IN : struct
+    public partial class RecursiveDescentSyntaxParser<IN, OUT> : ISyntaxParser<IN, OUT> where IN : struct, Enum
     {
       
 

--- a/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParser.EBNFRecursiveDescentSyntaxParser.Choice.cs
+++ b/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParser.EBNFRecursiveDescentSyntaxParser.Choice.cs
@@ -8,7 +8,7 @@ using sly.parser.syntax.tree;
 
 namespace sly.parser.llparser.ebnf;
 
-public partial class EBNFRecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+public partial class EBNFRecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
 {
     #region parsing
 

--- a/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParser.Many.cs
+++ b/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParser.Many.cs
@@ -7,7 +7,7 @@ using sly.parser.syntax.tree;
 
 namespace sly.parser.llparser.ebnf;
 
-public partial class EBNFRecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+public partial class EBNFRecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
 {
     #region parsing
 

--- a/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParser.Option.cs
+++ b/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParser.Option.cs
@@ -6,7 +6,7 @@ using sly.parser.syntax.tree;
 
 namespace sly.parser.llparser.ebnf;
 
-public partial class EBNFRecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+public partial class EBNFRecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
 {
     #region parsing
 

--- a/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParser.cs
+++ b/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParser.cs
@@ -9,7 +9,7 @@ using sly.parser.llparser.bnf;
 
 namespace sly.parser.llparser.ebnf
 {
-    public partial  class EBNFRecursiveDescentSyntaxParser<IN, OUT> : RecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+    public partial  class EBNFRecursiveDescentSyntaxParser<IN, OUT> : RecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
     {
         public EBNFRecursiveDescentSyntaxParser(ParserConfiguration<IN, OUT> configuration, string startingNonTerminal, string i18n)
             : base(configuration, startingNonTerminal, i18n)

--- a/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParserStarter.cs
+++ b/src/sly/parser/parser/llparser/ebnf/EBNFRecursiveDescentSyntaxParserStarter.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using sly.parser.generator;
 using sly.parser.syntax.grammar;
 
 namespace sly.parser.llparser.ebnf
 {
-    public partial class EBNFRecursiveDescentSyntaxParser<IN, OUT> where IN : struct
+    public partial class EBNFRecursiveDescentSyntaxParser<IN, OUT> where IN : struct, Enum
     {
 
         #region STARTING_TOKENS

--- a/src/sly/parser/syntax/grammar/ChoiceClause.cs
+++ b/src/sly/parser/syntax/grammar/ChoiceClause.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace sly.parser.syntax.grammar
 {
-    public sealed class ChoiceClause<IN,OUT> : IClause<IN,OUT> where IN : struct
+    public sealed class ChoiceClause<IN,OUT> : IClause<IN,OUT> where IN : struct, Enum
     {
 
         public bool IsDiscarded { get; set; } = false;

--- a/src/sly/parser/syntax/grammar/ClauseSequence.cs
+++ b/src/sly/parser/syntax/grammar/ClauseSequence.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace sly.parser.syntax.grammar
 {
-    public sealed class ClauseSequence<IN,OUT> : IClause<IN,OUT> where IN : struct
+    public sealed class ClauseSequence<IN,OUT> : IClause<IN,OUT> where IN : struct, Enum
     {
         public ClauseSequence(IClause<IN,OUT> item)
         {

--- a/src/sly/parser/syntax/grammar/GrammarNode.cs
+++ b/src/sly/parser/syntax/grammar/GrammarNode.cs
@@ -1,6 +1,8 @@
-﻿namespace sly.parser.syntax.grammar
+﻿using System;
+
+namespace sly.parser.syntax.grammar
 {
-    public interface GrammarNode<IN,OUT> where IN : struct
+    public interface GrammarNode<IN,OUT> where IN : struct, Enum
     {
     }
 }

--- a/src/sly/parser/syntax/grammar/GroupClause.cs
+++ b/src/sly/parser/syntax/grammar/GroupClause.cs
@@ -3,11 +3,12 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Linq;
+using System;
 
 namespace sly.parser.syntax.grammar
 {
     [DebuggerDisplay("{ToString()}")]
-    public sealed class GroupClause<IN,OUT> : IClause<IN,OUT> where IN : struct
+    public sealed class GroupClause<IN,OUT> : IClause<IN,OUT> where IN : struct, Enum
     {
         public GroupClause(IClause<IN,OUT> clause)
         {

--- a/src/sly/parser/syntax/grammar/IClause.cs
+++ b/src/sly/parser/syntax/grammar/IClause.cs
@@ -6,7 +6,7 @@ namespace sly.parser.syntax.grammar
     ///     a clause within a grammar rule
     /// </summary>
     /// <typeparam name="IN"></typeparam>
-    public interface IClause<IN,OUT> : GrammarNode<IN,OUT>, IEquatable<IClause<IN,OUT>> where IN : struct
+    public interface IClause<IN,OUT> : GrammarNode<IN,OUT>, IEquatable<IClause<IN,OUT>> where IN : struct, Enum
     {
         bool MayBeEmpty();
         string Dump();

--- a/src/sly/parser/syntax/grammar/LeadingToken.cs
+++ b/src/sly/parser/syntax/grammar/LeadingToken.cs
@@ -4,7 +4,7 @@ using sly.lexer;
 
 namespace sly.parser.syntax.grammar
 {
-    public sealed class LeadingToken<IN> : IEquatable<LeadingToken<IN>> where IN:struct 
+    public sealed class LeadingToken<IN> : IEquatable<LeadingToken<IN>> where IN:struct, Enum
     {
         public IN TokenId { get; set; }
         

--- a/src/sly/parser/syntax/grammar/ManyClause.cs
+++ b/src/sly/parser/syntax/grammar/ManyClause.cs
@@ -1,6 +1,8 @@
-﻿namespace sly.parser.syntax.grammar
+﻿using System;
+
+namespace sly.parser.syntax.grammar
 {
-    public abstract class ManyClause<IN,OUT> : IClause<IN,OUT> where IN : struct
+    public abstract class ManyClause<IN,OUT> : IClause<IN,OUT> where IN : struct, Enum
     {
         public IClause<IN,OUT> Clause { get; set; }
 

--- a/src/sly/parser/syntax/grammar/NonTerminalClause.cs
+++ b/src/sly/parser/syntax/grammar/NonTerminalClause.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace sly.parser.syntax.grammar
 {
-    public sealed class NonTerminalClause<IN,OUT> : IClause<IN,OUT> where IN : struct
+    public sealed class NonTerminalClause<IN,OUT> : IClause<IN,OUT> where IN : struct, Enum
     {
         public NonTerminalClause(string name)
         {

--- a/src/sly/parser/syntax/grammar/OneOrMoreClause.cs
+++ b/src/sly/parser/syntax/grammar/OneOrMoreClause.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace sly.parser.syntax.grammar
 {
-    public sealed class OneOrMoreClause<IN,OUT> : ManyClause<IN,OUT> where IN : struct
+    public sealed class OneOrMoreClause<IN,OUT> : ManyClause<IN,OUT> where IN : struct, Enum
     {
         public OneOrMoreClause(IClause<IN,OUT> clause)
         {

--- a/src/sly/parser/syntax/grammar/OptionClause.cs
+++ b/src/sly/parser/syntax/grammar/OptionClause.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace sly.parser.syntax.grammar
 {
-    public sealed class OptionClause<IN,OUT> : IClause<IN,OUT> where IN : struct
+    public sealed class OptionClause<IN,OUT> : IClause<IN,OUT> where IN : struct, Enum
     {
         public OptionClause(IClause<IN,OUT> clause)
         {

--- a/src/sly/parser/syntax/grammar/RepeatClause.cs
+++ b/src/sly/parser/syntax/grammar/RepeatClause.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace sly.parser.syntax.grammar
 {
-    public sealed class RepeatClause<IN,OUT> : ManyClause<IN,OUT> where IN : struct
+    public sealed class RepeatClause<IN,OUT> : ManyClause<IN,OUT> where IN : struct, Enum
     {
         public int MinRepetitionCount { get; set; }
         

--- a/src/sly/parser/syntax/grammar/Rule.cs
+++ b/src/sly/parser/syntax/grammar/Rule.cs
@@ -9,7 +9,7 @@ using sly.parser.generator;
 
 namespace sly.parser.syntax.grammar
 {
-    public class Rule<IN,OUT> : GrammarNode<IN,OUT> where IN : struct
+    public class Rule<IN,OUT> : GrammarNode<IN,OUT> where IN : struct, Enum
     {
         public Rule()
         {

--- a/src/sly/parser/syntax/grammar/TerminalClause.cs
+++ b/src/sly/parser/syntax/grammar/TerminalClause.cs
@@ -7,7 +7,7 @@ using sly.lexer;
 namespace sly.parser.syntax.grammar
 {
     [DebuggerDisplay("Terminal {(ExpectedToken.ToString())}{Discarded ? \"[d]\" : \"\"}")]
-    public class TerminalClause<IN,OUT> : IClause<IN,OUT> where IN : struct
+    public class TerminalClause<IN,OUT> : IClause<IN,OUT> where IN : struct, Enum
     {
         public TerminalClause(LeadingToken<IN> token)
         {
@@ -101,7 +101,7 @@ namespace sly.parser.syntax.grammar
         UnIndent
     }
     
-    public sealed class IndentTerminalClause<T,OUT> : TerminalClause<T,OUT> where T : struct
+    public sealed class IndentTerminalClause<T,OUT> : TerminalClause<T,OUT> where T : struct, Enum
     {
         private IndentationType ExpectedIndentation;
         

--- a/src/sly/parser/syntax/grammar/ZeroOrMoreClause.cs
+++ b/src/sly/parser/syntax/grammar/ZeroOrMoreClause.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace sly.parser.syntax.grammar
 {
-    public sealed class ZeroOrMoreClause<IN,OUT> : ManyClause<IN,OUT> where IN : struct
+    public sealed class ZeroOrMoreClause<IN,OUT> : ManyClause<IN,OUT> where IN : struct, Enum
     {
         
         public ZeroOrMoreClause(IClause<IN,OUT> clause)

--- a/src/sly/parser/syntax/tree/GroupSyntaxNode.cs
+++ b/src/sly/parser/syntax/tree/GroupSyntaxNode.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Collections.Generic;
 
 namespace sly.parser.syntax.tree
 {
-    public class GroupSyntaxNode<IN, OUT> : ManySyntaxNode<IN, OUT> where IN : struct
+    public class GroupSyntaxNode<IN, OUT> : ManySyntaxNode<IN, OUT> where IN : struct, Enum
     {
         public GroupSyntaxNode(string name) : base(name)
         {

--- a/src/sly/parser/syntax/tree/ISyntaxNode.cs
+++ b/src/sly/parser/syntax/tree/ISyntaxNode.cs
@@ -1,6 +1,8 @@
-﻿namespace sly.parser.syntax.tree
+﻿using System;
+
+namespace sly.parser.syntax.tree
 {
-    public interface ISyntaxNode<IN, OUT> where IN : struct
+    public interface ISyntaxNode<IN, OUT> where IN : struct, Enum
     {
 
         public bool IsEpsilon { get;}

--- a/src/sly/parser/syntax/tree/ManySyntaxNode.cs
+++ b/src/sly/parser/syntax/tree/ManySyntaxNode.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Collections.Generic;
 
 namespace sly.parser.syntax.tree
 {
-    public class ManySyntaxNode<IN, OUT> : SyntaxNode<IN, OUT> where IN : struct
+    public class ManySyntaxNode<IN, OUT> : SyntaxNode<IN, OUT> where IN : struct, Enum
     {
         public ManySyntaxNode(string name) : base(name, new List<ISyntaxNode<IN, OUT>>())
         {

--- a/src/sly/parser/syntax/tree/OptionSyntaxNode.cs
+++ b/src/sly/parser/syntax/tree/OptionSyntaxNode.cs
@@ -1,9 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
 namespace sly.parser.syntax.tree
 {
-    public class OptionSyntaxNode<IN, OUT> : SyntaxNode<IN, OUT> where IN : struct
+    public class OptionSyntaxNode<IN, OUT> : SyntaxNode<IN, OUT> where IN : struct, Enum
     {
         public bool IsGroupOption { get; set; } = false;
 

--- a/src/sly/parser/syntax/tree/SyntaxLeaf.cs
+++ b/src/sly/parser/syntax/tree/SyntaxLeaf.cs
@@ -1,8 +1,10 @@
+using System;
+
 using sly.lexer;
 
 namespace sly.parser.syntax.tree
 {
-    public class SyntaxLeaf<IN, OUT> : ISyntaxNode<IN, OUT> where IN : struct
+    public class SyntaxLeaf<IN, OUT> : ISyntaxNode<IN, OUT> where IN : struct, Enum
     {
         public SyntaxLeaf(Token<IN> token, bool discarded)
         {

--- a/src/sly/parser/syntax/tree/SyntaxNode.cs
+++ b/src/sly/parser/syntax/tree/SyntaxNode.cs
@@ -8,7 +8,7 @@ using sly.parser.generator;
 
 namespace sly.parser.syntax.tree
 {
-    public class SyntaxNode<IN, OUT> : ISyntaxNode<IN, OUT> where IN : struct
+    public class SyntaxNode<IN, OUT> : ISyntaxNode<IN, OUT> where IN : struct, Enum
     {
         
         public SyntaxNode(string name, List<ISyntaxNode<IN, OUT>> children = null, MethodInfo visitor = null)

--- a/tests/ParserTests/NFluentParseExtensions.cs
+++ b/tests/ParserTests/NFluentParseExtensions.cs
@@ -1,8 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using NFluent;
 using NFluent.Extensibility;
 using NFluent.Kernel;
+
 using sly.buildresult;
 using sly.lexer;
 using sly.parser;
@@ -11,7 +14,7 @@ namespace ParserTests
 {
     public static class NFluentParseExtensions
     {
-        public static ICheckLink<ICheck<ParseResult<IN,OUT>>> IsOkParsing<IN,OUT>(this ICheck<ParseResult<IN,OUT>> context, bool checkIfResultisNull = true) where IN : struct
+        public static ICheckLink<ICheck<ParseResult<IN,OUT>>> IsOkParsing<IN,OUT>(this ICheck<ParseResult<IN,OUT>> context, bool checkIfResultisNull = true) where IN : struct, Enum
         {
             ExtensibilityHelper.BeginCheck(context)
                 .FailWhen(sut => sut.IsError, $"parse failed")
@@ -21,7 +24,7 @@ namespace ParserTests
             return ExtensibilityHelper.BuildCheckLink(context);
         }
         
-        public static ICheckLink<ICheck<LexerResult<IN>>> IsOkLexing<IN>(this ICheck<LexerResult<IN>> context) where IN : struct
+        public static ICheckLink<ICheck<LexerResult<IN>>> IsOkLexing<IN>(this ICheck<LexerResult<IN>> context) where IN : struct, Enum
         {
             ExtensibilityHelper.BeginCheck(context)
                 .FailWhen(sut => sut == null, "lexer result is null")
@@ -54,7 +57,7 @@ namespace ParserTests
             return ExtensibilityHelper.BuildCheckLink(context);
         }
 
-        public static ICheckLink<ICheck<Token<T>>> IsEqualTo<T>(this ICheck<Token<T>> context, T expectedTokenId, string expectedValue) where T: struct
+        public static ICheckLink<ICheck<Token<T>>> IsEqualTo<T>(this ICheck<Token<T>> context, T expectedTokenId, string expectedValue) where T: struct, Enum
         {
             ExtensibilityHelper.BeginCheck(context)
                 .FailWhen(sut => !sut.TokenID.Equals(expectedTokenId), "expecting {expected} found {checked}.")
@@ -65,7 +68,7 @@ namespace ParserTests
             return ExtensibilityHelper.BuildCheckLink(context);
         }
         
-        public static ICheckLink<ICheck<Token<T>>> IsEqualTo<T>(this ICheck<Token<T>> context, T expectedTokenId, string expectedValue, int expectedLine, int expectedColumn) where T: struct
+        public static ICheckLink<ICheck<Token<T>>> IsEqualTo<T>(this ICheck<Token<T>> context, T expectedTokenId, string expectedValue, int expectedLine, int expectedColumn) where T: struct, Enum
         {
             ExtensibilityHelper.BeginCheck(context)
                 .FailWhen(sut => !sut.TokenID.Equals(expectedTokenId), "expecting {expected} found {checked}.")


### PR DESCRIPTION
- Add Enum constraint to token type in various classes and methods
- Update generic type definitions across multiple files
- Improve type safety and ensure tokens are always enum types